### PR TITLE
Add basic audio transcription and emotion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Emotion Knowledge
+
+This repository provides a minimal example of turning audio into text
+and annotating that text with emotions. The first implementation uses
+text-only emotion classification so it can be easily extended later to
+multimodal approaches.
+
+## Overview
+
+1. **AudioTranscriber** – converts an audio file to text using the
+   Hugging Face `transformers` ASR pipeline (Whisper).
+2. **TextEmotionAnnotator** – detects emotions in the text using a
+   transformers text-classification model.
+3. **EmotionTranscriptionPipeline** – orchestrates the two steps. It
+   returns both the plain transcription and the emotion-enriched text.
+
+The code is structured so additional components can be inserted, such as
+an audio-based emotion model.
+
+## Usage
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the example:
+
+```bash
+python emotion_transcriber.py path/to/audio.wav
+```
+
+The script prints the plain transcription and the transcription with
+emotion labels.
+
+## Testing
+
+Run tests with:
+
+```bash
+pytest
+```
+
+Tests use lightweight stubs so they run without downloading heavy
+models.

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -1,0 +1,60 @@
+import argparse
+from dataclasses import dataclass
+from typing import Tuple
+
+from transformers import pipeline
+
+
+@dataclass
+class AudioTranscriber:
+    """Convert audio to text using a transformers ASR pipeline."""
+
+    model: str = "openai/whisper-base"
+
+    def __post_init__(self) -> None:
+        self.pipeline = pipeline("automatic-speech-recognition", model=self.model)
+
+    def __call__(self, audio_path: str) -> str:
+        result = self.pipeline(audio_path)
+        return result["text"].strip()
+
+
+@dataclass
+class TextEmotionAnnotator:
+    """Annotate text with emotions using a transformers classifier."""
+
+    model: str = "j-hartmann/emotion-english-distilroberta-base"
+
+    def __post_init__(self) -> None:
+        self.pipeline = pipeline("text-classification", model=self.model, return_all_scores=True)
+
+    def __call__(self, text: str) -> str:
+        scores = self.pipeline(text)[0]
+        top = max(scores, key=lambda s: s["score"])
+        return f"[{top['label']}] {text}"
+
+
+@dataclass
+class EmotionTranscriptionPipeline:
+    transcriber: AudioTranscriber
+    annotator: TextEmotionAnnotator
+
+    def __call__(self, audio_path: str) -> Tuple[str, str]:
+        text = self.transcriber(audio_path)
+        annotated = self.annotator(text)
+        return text, annotated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transcribe audio and annotate emotions")
+    parser.add_argument("audio", help="Path to an audio file")
+    args = parser.parse_args()
+
+    pipeline = EmotionTranscriptionPipeline(AudioTranscriber(), TextEmotionAnnotator())
+    text, annotated = pipeline(args.audio)
+    print("Plain transcription:\n", text)
+    print("\nWith emotion:\n", annotated)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+transformers==4.38.2
+langchain==0.1.13
+pydub
+torchaudio

--- a/tests/test_emotion_transcriber.py
+++ b/tests/test_emotion_transcriber.py
@@ -1,0 +1,33 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import types
+
+from emotion_knowledge import EmotionTranscriptionPipeline, AudioTranscriber, TextEmotionAnnotator
+
+
+class DummyTranscriber(AudioTranscriber):
+    def __post_init__(self):
+        self.called = False
+
+    def __call__(self, audio_path: str) -> str:
+        self.called = True
+        return "hello world"
+
+
+class DummyAnnotator(TextEmotionAnnotator):
+    def __post_init__(self):
+        self.called = False
+
+    def __call__(self, text: str) -> str:
+        self.called = True
+        return "[happy] " + text
+
+
+def test_pipeline_runs_with_dummies(tmp_path):
+    audio_file = tmp_path / "fake.wav"
+    audio_file.write_text("fake audio")
+    pipeline = EmotionTranscriptionPipeline(DummyTranscriber(), DummyAnnotator())
+    text, annotated = pipeline(str(audio_file))
+    assert text == "hello world"
+    assert annotated == "[happy] hello world"
+    assert pipeline.transcriber.called
+    assert pipeline.annotator.called


### PR DESCRIPTION
## Summary
- implement audio transcription to text using Whisper via `transformers`
- add text emotion annotation using a transformers classifier
- orchestrate steps with a simple pipeline
- provide lightweight tests using dummy classes
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590d208aec83299e35ddc1ace1e293