### PR TITLE
Handle long text in TextEmotionAnnotator

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -21,7 +21,11 @@ class AudioTranscriber:
 
 @dataclass
 class TextEmotionAnnotator:
-    """Annotate text with emotions using a transformers classifier."""
+    """Annotate text with emotions using a transformers classifier.
+
+    Long inputs are truncated to the model's maximum length when the
+    underlying pipeline is called.
+    """
 
     model: str = "j-hartmann/emotion-english-distilroberta-base"
 
@@ -29,7 +33,7 @@ class TextEmotionAnnotator:
         self.pipeline = pipeline("text-classification", model=self.model, return_all_scores=True)
 
     def __call__(self, text: str) -> str:
-        scores = self.pipeline(text)[0]
+        scores = self.pipeline(text, truncation=True)[0]
         top = max(scores, key=lambda s: s["score"])
         return f"[{top['label']}] {text}"
 

--- a/tests/test_emotion_transcriber.py
+++ b/tests/test_emotion_transcriber.py
@@ -22,6 +22,17 @@ class DummyAnnotator(TextEmotionAnnotator):
         return "[happy] " + text
 
 
+class TruncationCapturingAnnotator(TextEmotionAnnotator):
+    def __post_init__(self):
+        self.captured = {}
+
+        def dummy(text, truncation=False, **kwargs):
+            self.captured["truncation"] = truncation
+            return [[{"label": "happy", "score": 1.0}]]
+
+        self.pipeline = dummy
+
+
 def test_pipeline_runs_with_dummies(tmp_path):
     audio_file = tmp_path / "fake.wav"
     audio_file.write_text("fake audio")
@@ -31,3 +42,11 @@ def test_pipeline_runs_with_dummies(tmp_path):
     assert annotated == "[happy] hello world"
     assert pipeline.transcriber.called
     assert pipeline.annotator.called
+
+
+def test_annotator_truncates_long_text():
+    annotator = TruncationCapturingAnnotator()
+    long_text = "word " * 600
+    result = annotator(long_text)
+    assert annotator.captured.get("truncation") is True
+    assert result.startswith("[happy]")


### PR DESCRIPTION
## Summary
- truncate long text inputs when running the emotion classifier
- describe truncation in the TextEmotionAnnotator docstring
- test that truncation flag is forwarded when text exceeds model length

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594d285de0832988aa567fb71e4b31