### PR TITLE
Document default German models and stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ multimodal approaches.
 The code is structured so additional components can be inserted, such as
 an audio-based emotion model.
 
+## Default models
+
+The built-in classes work with German data. `AudioTranscriber` loads
+`openai/whisper-base` with `language='de'` for speech recognition, while
+`TextEmotionAnnotator` uses `oliverguhr/german-emotion-bert` for emotion
+classification.
+
 ## Usage
 
 Install dependencies with:
@@ -43,4 +50,6 @@ pytest
 ```
 
 Tests use lightweight stubs so they run without downloading heavy
-models.
+models. A tiny `transformers` package in `transformers/` provides the
+stub. Remove or bypass this directory when running the example with the
+real `transformers` library so the actual models are loaded.

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -7,7 +7,11 @@ from transformers import pipeline
 
 @dataclass
 class AudioTranscriber:
-    """Convert audio to text using a transformers ASR pipeline."""
+    """Convert audio to text using a transformers ASR pipeline.
+
+    The default model is ``openai/whisper-base`` configured with
+    ``language='de'`` for German speech recognition.
+    """
 
     model: str = "openai/whisper-base"
 
@@ -28,8 +32,9 @@ class AudioTranscriber:
 class TextEmotionAnnotator:
     """Annotate text with emotions using a transformers classifier.
 
-    Long inputs are truncated to the model's maximum length when the
-    underlying pipeline is called.
+    The default model is ``oliverguhr/german-emotion-bert``, so text should be
+    in German. Long inputs are truncated to the model's maximum length when
+    the underlying pipeline is called.
     """
 
     model: str = "oliverguhr/german-emotion-bert"


### PR DESCRIPTION
## Summary
- document German defaults in the README
- mention the lightweight transformers stub
- clarify defaults in `AudioTranscriber` and `TextEmotionAnnotator` docstrings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859571aa0648329b2f69a57dc6e6fb9