### PR TITLE
Fix pipeline task duplication, adjust tests

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -20,7 +20,6 @@ class AudioTranscriber:
             "automatic-speech-recognition",
             model=self.model,
             language="de",
-            task="transcribe",
         )
 
     def __call__(self, audio_path: str) -> str:

--- a/tests/test_emotion_transcriber.py
+++ b/tests/test_emotion_transcriber.py
@@ -57,5 +57,6 @@ def test_transcriber_passes_pipeline_kwargs():
 
     with patch("emotion_knowledge.pipeline", Mock(return_value=Mock())) as mock:
         AudioTranscriber()
+        assert mock.call_args.args[0] == "automatic-speech-recognition"
+        assert mock.call_args.kwargs.get("model") == "openai/whisper-base"
         assert mock.call_args.kwargs.get("language") == "de"
-        assert mock.call_args.kwargs.get("task") == "transcribe"


### PR DESCRIPTION
## Summary
- update `AudioTranscriber` to pass only one task argument when initializing the HF pipeline
- update tests to verify the positional task argument and model name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595acc25bc83299c4cf79b406af572