### PR TITLE
Update ASR language usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ an audio-based emotion model.
 
 ## Default models
 
-The built-in classes work with German data. `AudioTranscriber` loads
-`openai/whisper-base` with `language='de'` for speech recognition, while
+The built-in classes work with German data. `AudioTranscriber` uses
+`openai/whisper-base` for speech recognition and passes
+`language='de'` when invoking the pipeline, while
 `TextEmotionAnnotator` uses `oliverguhr/german-emotion-bert` for emotion
 classification.
 

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -12,8 +12,9 @@ except Exception:  # pragma: no cover - fallback when transformers isn't install
 class AudioTranscriber:
     """Convert audio to text using a transformers ASR pipeline.
 
-    The default model is ``openai/whisper-base`` configured with
-    ``language='de'`` for German speech recognition.
+    The default model is ``openai/whisper-base`` for German speech
+    recognition. The ``language`` option is passed when the pipeline is
+    invoked rather than during initialisation.
     """
 
     model: str = "openai/whisper-base"
@@ -22,11 +23,10 @@ class AudioTranscriber:
         self.pipeline = pipeline(
             "automatic-speech-recognition",
             model=self.model,
-            language="de",
         )
 
     def __call__(self, audio_path: str) -> str:
-        result = self.pipeline(audio_path)
+        result = self.pipeline(audio_path, generate_kwargs={"language": "de"})
         return result["text"].strip()
 
 


### PR DESCRIPTION
## Summary
- pass language when invoking the ASR pipeline rather than in `__post_init__`
- update README to document new approach
- test that `AudioTranscriber` calls the pipeline with language at runtime

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68595fabbd0483299393a2c38f216ef7