### PR TITLE
Add WhisperX diarization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
-Run the example:
+Run a transcription:
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav
 ```
 
-The script prints the plain transcription and the transcription with
-emotion labels.
+Add `--diarize` to enable speaker diarization with WhisperX:
+
+```bash
+python -m emotion_knowledge path/to/audio.wav --diarize
+```
+
+The script prints the resulting transcription to the console.
 

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -1,8 +1,47 @@
 import argparse
-from langchain_core.tools import tool
-from langchain_core.runnables import Runnable
-import whisper
 import os
+from langchain_core.runnables import Runnable
+from langchain_core.tools import tool
+import whisper
+
+
+@tool
+def transcribe_diarize_whisperx(audio_path: str) -> str:
+    """Transkribiert Audio auf Deutsch mit WhisperX und Speaker-Diarization."""
+    import torch
+    import whisperx
+
+    assert os.path.exists(audio_path), f"Datei nicht gefunden: {audio_path}"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    model = whisperx.load_model("large-v3", device=device, language="de")
+    result = model.transcribe(audio_path)
+
+    align_model, metadata = whisperx.load_align_model(
+        language_code="de", device=device
+    )
+    result = whisperx.align(
+        result["segments"], align_model, metadata, audio_path, device=device
+    )
+
+    diarize_model = whisperx.DiarizationPipeline(device=device)
+    diarize_segments = diarize_model(audio_path)
+    words = whisperx.assign_word_speakers(diarize_segments, result["word_segments"])
+
+    lines = []
+    current_speaker = None
+    current_line = ""
+    for word in words:
+        speaker = word.get("speaker", "Speaker")
+        if speaker != current_speaker:
+            if current_line:
+                lines.append(f"[{current_speaker}] {current_line.strip()}")
+                current_line = ""
+            current_speaker = speaker
+        current_line += word["text"] + " "
+    if current_line:
+        lines.append(f"[{current_speaker}] {current_line.strip()}")
+    return "\n".join(lines)
 
 
 @tool
@@ -24,12 +63,32 @@ class TranscriptionOnlyWorkflow(Runnable):
         return text
 
 
+class WhisperXDiarizationWorkflow(Runnable):
+    """Workflow für Transkription und Speaker-Diarization mit WhisperX."""
+
+    def invoke(self, audio_path: str) -> str:
+        text = transcribe_diarize_whisperx.invoke(audio_path)
+        print("📄 Transkription mit Sprecherlabels:\n")
+        print(text)
+        return text
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Nur Transkription mit Whisper durchführen.")
+    parser = argparse.ArgumentParser(
+        description="Transkription deutscher Audiodateien mit optionaler Diarization."
+    )
     parser.add_argument("audio", help="Pfad zur Audiodatei (WAV/MP3)")
+    parser.add_argument(
+        "--diarize",
+        action="store_true",
+        help="Speaker-Diarization mit WhisperX verwenden",
+    )
     args = parser.parse_args()
 
-    workflow = TranscriptionOnlyWorkflow()
+    if args.diarize:
+        workflow = WhisperXDiarizationWorkflow()
+    else:
+        workflow = TranscriptionOnlyWorkflow()
     _ = workflow.invoke(args.audio)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 transformers==4.38.2
+whisperx


### PR DESCRIPTION
## Summary
- add WhisperX-based transcription with speaker diarization
- expose new `WhisperXDiarizationWorkflow` via CLI `--diarize`
- document new option in README
- require `whisperx` package

## Testing
- `python -m emotion_knowledge emotion_knowledge/arena.mp3 --diarize` *(fails: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_685a87f611008329864974f49422fa7d