### PR TITLE
Fix speaker diarization call

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -32,7 +32,7 @@ def transcribe_diarize_whisperx(audio_path: str) -> str:
     diarize_model = whisperx.DiarizationPipeline(device=device, use_auth_token=token)
     diarize_segments = diarize_model(audio_path)
 
-    words = whisperx.assign_word_speakers(diarize_segments, {"segments": word_segments})
+    words = whisperx.assign_word_speakers(diarize_segments, aligned_output)
     
     lines = []
     current_speaker = None


### PR DESCRIPTION
## Summary
- pass the full aligned output to `assign_word_speakers`

## Testing
- `python -m py_compile emotion_knowledge/__init__.py`
- `python -m emotion_knowledge --help` *(fails: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_685ac31caea48329baca080401c570a1