### PR TITLE
Fix speaker diarization call

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -32,8 +32,11 @@ def transcribe_diarize_whisperx(audio_path: str) -> str:
     diarize_model = whisperx.DiarizationPipeline(device=device, use_auth_token=token)
     diarize_segments = diarize_model(audio_path)
 
-    words = whisperx.assign_word_speakers(diarize_segments, {"segments": word_segments})
-    
+    result_with_speakers = whisperx.assign_word_speakers(
+        diarize_segments, aligned_output
+    )
+
+    words = result_with_speakers["word_segments"]
     lines = []
     current_speaker = None
     current_line = ""


### PR DESCRIPTION
## Summary
- pass the entire aligned output to `assign_word_speakers`
- extract the labeled word segments before building the transcript

## Testing
- `python -m py_compile emotion_knowledge/__init__.py`
- `python -m emotion_knowledge --help`


------
https://chatgpt.com/codex/tasks/task_e_685ac31caea48329baca080401c570a1