### PR TITLE
Fix word-text key handling

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -47,7 +47,8 @@ def transcribe_diarize_whisperx(audio_path: str) -> str:
                 lines.append(f"[{current_speaker}] {current_line.strip()}")
                 current_line = ""
             current_speaker = speaker
-        current_line += word["text"] + " "
+        word_text = word.get("text", word.get("word", ""))
+        current_line += word_text + " "
     if current_line:
         lines.append(f"[{current_speaker}] {current_line.strip()}")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- handle either `word` or `text` key when building transcription

## Testing
- `python -m py_compile emotion_knowledge/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685ae21f97b083298551e9ecbe5c90ed