### PR TITLE
Add emotion detection pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ multimodal approaches.
 
 1. **AudioTranscriber** – converts an audio file to text using the
    Hugging Face `transformers` ASR pipeline (Whisper).
-2. **TextEmotionAnnotator** – prompts a Llama model to label the emotion
-   of the text.
-3. **EmotionTranscriptionPipeline** – orchestrates the two steps. It
-   returns both the plain transcription and the emotion-enriched text.
+2. **TextEmotionAnnotator** – prompts a Llama model to label the emotion of the text.
+3. **EmotionTranscriptionPipeline** – orchestrates the two steps. It returns both the plain transcription and the emotion-enriched text.
+4. **EmotionDetector** – uses a multimodal Hugging Face model to detect the emotion of each diarized segment.
+5. **TranscriptFormatter** – formats the annotated segments for display.
+
+The new `emotion_transcription_pipeline()` function chains these Runnables using LangChain so you can process audio end-to-end:
+
+```python
+from emotion_knowledge.pipeline import emotion_transcription_pipeline
+
+pipeline = emotion_transcription_pipeline()
+print(pipeline.invoke("path/to/audio.wav"))
+```
 
 The code is structured so additional components can be inserted, such as
 an audio-based emotion model.

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -4,6 +4,13 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools import tool
 import whisper
 
+from .pipeline import (
+    AudioTranscriber,
+    EmotionDetector,
+    TranscriptFormatter,
+    emotion_transcription_pipeline,
+)
+
 
 @tool
 def transcribe_diarize_whisperx(audio_path: str) -> str:

--- a/emotion_knowledge/pipeline.py
+++ b/emotion_knowledge/pipeline.py
@@ -1,0 +1,86 @@
+"""LangChain Runnables for diarized emotion recognition."""
+
+from __future__ import annotations
+
+import os
+from typing import List, Dict, Any
+
+import torch
+from langchain_core.runnables import Runnable
+from transformers import AutoModelForSequenceClassification, AutoProcessor
+
+from . import transcribe_diarize_whisperx
+
+
+class AudioTranscriber(Runnable):
+    """Transcribes audio and returns diarized segments."""
+
+    def invoke(self, audio_path: str) -> List[Dict[str, Any]]:
+        text = transcribe_diarize_whisperx.invoke(audio_path)
+        # Each line from transcribe_diarize_whisperx has format: [Speaker] text
+        segments = []
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            if line.startswith("[") and "]" in line:
+                speaker, utterance = line.split("]", 1)
+                segments.append({
+                    "speaker": speaker.strip("[]"),
+                    "text": utterance.strip(),
+                })
+        if not segments:
+            raise ValueError("No segments produced from transcription")
+        return segments
+
+
+class EmotionDetector(Runnable):
+    """Annotates segments with emotions using a HF model."""
+
+    def __init__(self, model_id: str = "ZebangCheng/Emotion-LLaMA") -> None:
+        device = 0 if torch.cuda.is_available() else -1
+        self.processor = AutoProcessor.from_pretrained(model_id)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_id)
+        if device >= 0:
+            self.model = self.model.to(device)
+        self.device = device
+
+    def invoke(self, segments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        annotated = []
+        for seg in segments:
+            inputs = self.processor(text=seg["text"], return_tensors="pt")
+            if self.device >= 0:
+                inputs = {k: v.to(self.device) for k, v in inputs.items()}
+            with torch.no_grad():
+                out = self.model(**inputs)
+            scores = out.logits.softmax(dim=-1)[0]
+            label_id = int(scores.argmax())
+            label = self.model.config.id2label[label_id]
+            seg = dict(seg)
+            seg["emotion"] = label
+            seg["confidence"] = float(scores[label_id])
+            annotated.append(seg)
+        return annotated
+
+
+class TranscriptFormatter(Runnable):
+    """Formats the annotated transcript."""
+
+    def invoke(self, segments: List[Dict[str, Any]]) -> str:
+        lines = []
+        for seg in segments:
+            speaker = seg.get("speaker", "Speaker")
+            emotion = seg.get("emotion", "")
+            line = f"[{speaker}][{emotion}] {seg['text']}"
+            lines.append(line)
+        return "\n".join(lines)
+
+
+# Convenience pipeline using RunnableSequence
+from langchain_core.runnables import RunnableSequence
+
+
+def emotion_transcription_pipeline(model_id: str = "ZebangCheng/Emotion-LLaMA") -> RunnableSequence:
+    transcriber = AudioTranscriber()
+    detector = EmotionDetector(model_id=model_id)
+    formatter = TranscriptFormatter()
+    return transcriber | detector | formatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 transformers==4.38.2
 whisperx
+langchain-core


### PR DESCRIPTION
## Summary
- add modular `EmotionDetector` and `TranscriptFormatter` runnables
- support chaining with `emotion_transcription_pipeline`
- export components from package
- document new pipeline in README
- add `langchain-core` to requirements

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685d08f907fc8329bde709dc60538f56