### PR TITLE
Fix circular import error in pipeline

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -4,12 +4,6 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools import tool
 import whisper
 
-from .pipeline import (
-    AudioTranscriber,
-    EmotionDetector,
-    TranscriptFormatter,
-    emotion_transcription_pipeline,
-)
 
 
 @tool


### PR DESCRIPTION
## Summary
- remove pipeline imports from `__init__` to avoid circular import when constructing the emotion transcription pipeline

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685d160c4d448329ac6305c91229a5da