### PR TITLE
Switch CLI to emotion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Run a transcription:
 python -m emotion_knowledge path/to/audio.wav
 ```
 
-Add `--diarize` to enable speaker diarization with WhisperX:
+Add `--diarize` to enable speaker diarization with WhisperX. You can
+choose a different WhisperX model size with `--model-size`:
 
 ```bash
-python -m emotion_knowledge path/to/audio.wav --diarize
+python -m emotion_knowledge path/to/audio.wav --diarize --model-size medium
 ```
 
 The script prints the resulting transcription to the console.


### PR DESCRIPTION
## Summary
- build transcriptions via `emotion_transcription_pipeline`
- allow choosing WhisperX model size via `--model-size`
- clean up debug prints
- document diarization and model size usage

## Testing
- `python -m emotion_knowledge --help` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_685d3dfe109083299b6667ffc7bc2cfa