### PR TITLE
Guard optional debug prints

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -28,6 +28,9 @@ def transcribe_diarize_whisperx(audio_path: str) -> str:
         result["segments"], align_model, metadata, audio_path, device=device
     )
     word_segments = aligned_output["word_segments"]
+    if os.getenv("EK_DEBUG"):
+        print(type(word_segments))
+        print(word_segments[:2])
 
     token = os.getenv("HF_TOKEN")  # set this in Colab/terminal
     diarize_model = whisperx.DiarizationPipeline(device=device, use_auth_token=token)


### PR DESCRIPTION
## Summary
- keep CLI helper quiet by default
- only print word segments when `EK_DEBUG` is set

## Testing
- `python -m py_compile emotion_knowledge/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685d41cf57a483298a79ccad2b65e57a