### PR TITLE
Allow passing config dicts

### DIFF
--- a/emotion_knowledge/pipeline.py
+++ b/emotion_knowledge/pipeline.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
-from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.runnables import Runnable
 from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
@@ -34,7 +34,7 @@ class AudioTranscriber(Runnable):
             )
 
     def invoke(
-        self, audio_path: str, config: RunnableConfig | None = None
+        self, audio_path: str, config: Optional[dict] = None
     ) -> List[Dict[str, Any]]:
         assert os.path.exists(audio_path), f"File not found: {audio_path}"
         result = self.model.transcribe(audio_path)
@@ -82,7 +82,7 @@ class EmotionAnnotator(Runnable):
         self.device = device
 
     def invoke(
-        self, segments: List[Dict[str, Any]], config: RunnableConfig | None = None
+        self, segments: List[Dict[str, Any]], config: Optional[dict] = None
     ) -> List[Dict[str, Any]]:
         annotated = []
         for seg in segments:
@@ -108,7 +108,7 @@ class TranscriptFormatter(Runnable):
     """Formats the annotated transcript."""
 
     def invoke(
-        self, segments: List[Dict[str, Any]], config: RunnableConfig | None = None
+        self, segments: List[Dict[str, Any]], config: Optional[dict] = None
     ) -> str:
         lines = []
         for seg in segments:


### PR DESCRIPTION
## Summary
- update invoke method signatures for `AudioTranscriber`, `EmotionAnnotator`, and `TranscriptFormatter` to take an optional `dict`
- drop unused `RunnableConfig` import

## Testing
- `python -m py_compile emotion_knowledge/pipeline.py`
- `pip install --quiet -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685d41d3daa08329b91bbeab80522962