### PR TITLE
Allow passing config dicts

### DIFF
--- a/emotion_knowledge/pipeline.py
+++ b/emotion_knowledge/pipeline.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
-from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.runnables import Runnable
 from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
@@ -34,8 +34,9 @@ class AudioTranscriber(Runnable):
             )
 
     def invoke(
-        self, audio_path: str, config: RunnableConfig | None = None
+        self, audio_path: str, config: Optional[dict] = None
     ) -> List[Dict[str, Any]]:
+        """Transcribe `audio_path`. The optional config dict is ignored."""
         assert os.path.exists(audio_path), f"File not found: {audio_path}"
         result = self.model.transcribe(audio_path)
         segments = result["segments"]
@@ -82,8 +83,9 @@ class EmotionAnnotator(Runnable):
         self.device = device
 
     def invoke(
-        self, segments: List[Dict[str, Any]], config: RunnableConfig | None = None
+        self, segments: List[Dict[str, Any]], config: Optional[dict] = None
     ) -> List[Dict[str, Any]]:
+        """Annotate segments with emotions. The optional config dict is ignored."""
         annotated = []
         for seg in segments:
             inputs = self.tokenizer(seg["text"], return_tensors="pt", truncation=True)
@@ -108,8 +110,9 @@ class TranscriptFormatter(Runnable):
     """Formats the annotated transcript."""
 
     def invoke(
-        self, segments: List[Dict[str, Any]], config: RunnableConfig | None = None
+        self, segments: List[Dict[str, Any]], config: Optional[dict] = None
     ) -> str:
+        """Format annotated segments. The optional config dict is ignored."""
         lines = []
         for seg in segments:
             speaker = seg.get("speaker", "Speaker")


### PR DESCRIPTION
## Summary
- update invoke method signatures for the audio transcription, emotion annotation, and transcript formatting stages
- describe the optional config parameter directly in each invoke method docstring

## Testing
- `python -m py_compile emotion_knowledge/pipeline.py`
- `pip install --quiet -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685d41d3daa08329b91bbeab80522962