### PR TITLE
Improve EmotionAnnotator memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ an audio-based emotion model.
 The built-in classes work with German data. `AudioTranscriber` loads the
 WhisperX ASR model (size *small* by default) with `language='de'`. The
 `EmotionAnnotator` relies on the `oliverguhr/german-sentiment-bert` model
-to classify each utterance as positive, neutral or negative.
+to classify each utterance as positive, neutral or negative. Long
+utterances are truncated and GPU cache is cleared after each prediction to
+keep memory usage low.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- release GPU memory after every sentiment inference
- trim long utterances before passing them to BERT
- document the new behaviour

## Testing
- `python -m emotion_knowledge emotion_knowledge/arena.mp3` *(fails: No module named 'langchain_core')*
- `pip install -q langchain-core` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d63471d88832994f9fe0b98bcc41a