### PR TITLE
Improve EmotionAnnotator memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ multimodal approaches.
 
 1. **AudioTranscriber** – transcribes German speech with WhisperX and can
     optionally perform speaker diarization.
-2. **EmotionAnnotator** – labels each utterance using the lightweight
-    `oliverguhr/german-sentiment-bert` model.
-3. **EmotionTranscriptionPipeline** – chains the components to produce a list of
+2. **SegmentDBWriter** – stores diarized segments in a Chroma DB and exports
+    per-speaker audio clips.
+3. **DBEmotionAnnotator** – fetches the stored segments one by one and annotates
+    them using the lightweight `oliverguhr/german-sentiment-bert` model.
+4. **EmotionTranscriptionPipeline** – chains the components to produce a list of
     annotated segments.
-4. **TranscriptFormatter** – formats the annotated segments for display.
+5. **TranscriptFormatter** – formats the annotated segments for display.
 
 The new `emotion_transcription_pipeline()` function chains these Runnables using LangChain so you can process audio end-to-end:
 
@@ -24,6 +26,10 @@ pipeline = emotion_transcription_pipeline()
 print(pipeline.invoke("path/to/audio.wav"))
 ```
 
+Each speaker segment is stored in a local Chroma database together with a
+per-speaker audio clip. You can rerun only the emotion step later by
+creating a `DBEmotionAnnotator` and calling it on the saved database.
+
 The code is structured so additional components can be inserted, such as
 an audio-based emotion model.
 
@@ -31,8 +37,10 @@ an audio-based emotion model.
 
 The built-in classes work with German data. `AudioTranscriber` loads the
 WhisperX ASR model (size *small* by default) with `language='de'`. The
-`EmotionAnnotator` relies on the `oliverguhr/german-sentiment-bert` model
-to classify each utterance as positive, neutral or negative.
+`DBEmotionAnnotator` relies on the `oliverguhr/german-sentiment-bert` model
+to classify each stored utterance as positive, neutral or negative. Long
+utterances are truncated and GPU cache is cleared after each prediction to
+keep memory usage low.
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 transformers==4.38.2
 whisperx
 langchain-core
+chromadb
+pydub


### PR DESCRIPTION
## Summary
- release GPU memory after every sentiment inference
- trim long utterances before passing them to BERT
- document the new behaviour

## Testing
- `python -m emotion_knowledge emotion_knowledge/arena.mp3` *(fails: No module named 'langchain_core')*
- `pip install -q langchain-core` *(fails due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_685d63471d88832994f9fe0b98bcc41a