### PR TITLE
Add modular German emotion transcription pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,18 @@ multimodal approaches.
 
 ## Overview
 
-1. **AudioTranscriber** – converts an audio file to text using the
-   Hugging Face `transformers` ASR pipeline (Whisper).
-2. **TextEmotionAnnotator** – prompts a Llama model to label the emotion
-   of the text.
-3. **EmotionTranscriptionPipeline** – orchestrates the two steps. It
-   returns both the plain transcription and the emotion-enriched text.
+1. **AudioTranscriber** – converts an audio file to text with Whisper or
+   WhisperX (German, optional diarization). Transcripts are cached on
+   disk.
+2. **SegmentDBWriter** – writes each utterance into a ChromaDB
+   collection and exports individual WAV clips.
+3. **DBEmotionAnnotator** – batches the texts in the database and runs a
+   German emotion classification model. Results are stored back in the
+   DB.
+4. **TranscriptFormatter** – formats the annotated segments as readable
+   strings.
+5. **emotion_transcription_pipeline** – combines all steps using
+   LangChain's ``RunnableSequence``.
 
 The code is structured so additional components can be inserted, such as
 an audio-based emotion model.
@@ -39,11 +45,13 @@ Run a transcription:
 python -m emotion_knowledge path/to/audio.wav
 ```
 
-Add `--diarize` to enable speaker diarization with WhisperX:
+Use `--diarize` for speaker labels and `--load-in-8bit` to reduce GPU
+memory usage. All settings can be configured via command line:
 
 ```bash
-python -m emotion_knowledge path/to/audio.wav --diarize
+python -m emotion_knowledge path/to/audio.wav --diarize --batch-size 16 \
+    --db-path mydb --clip-dir clips
 ```
 
-The script prints the resulting transcription to the console.
+The script prints the emotion-enriched transcript to the console.
 

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -106,3 +106,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+from .pipeline import emotion_transcription_pipeline

--- a/emotion_knowledge/__main__.py
+++ b/emotion_knowledge/__main__.py
@@ -1,4 +1,34 @@
-from . import main
+import argparse
+
+from .pipeline import emotion_transcription_pipeline
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="German speech-to-emotion transcription pipeline"
+    )
+    parser.add_argument("audio", help="Path to audio file")
+    parser.add_argument("--diarize", action="store_true", help="Use speaker diarization")
+    parser.add_argument("--model-size", default="base", help="Whisper model size")
+    parser.add_argument("--emotion-model", default="oliverguhr/german-emotion-bert", help="HuggingFace emotion model")
+    parser.add_argument("--db-path", default="db", help="ChromaDB directory")
+    parser.add_argument("--clip-dir", default="clips", help="Directory for audio clips")
+    parser.add_argument("--batch-size", type=int, default=8, help="Emotion batch size")
+    parser.add_argument("--load-in-8bit", action="store_true", help="Load emotion model in 8bit")
+    args = parser.parse_args()
+
+    pipeline = emotion_transcription_pipeline(
+        diarize=args.diarize,
+        model_size=args.model_size,
+        emotion_model=args.emotion_model,
+        db_path=args.db_path,
+        clip_dir=args.clip_dir,
+        batch_size=args.batch_size,
+        load_in_8bit=args.load_in_8bit,
+    )
+    output = pipeline.invoke(args.audio)
+    print(output)
+
 
 if __name__ == "__main__":
     main()

--- a/emotion_knowledge/audio_transcriber.py
+++ b/emotion_knowledge/audio_transcriber.py
@@ -1,0 +1,52 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+
+
+class AudioTranscriber:
+    """Transcribe German audio with optional speaker diarization."""
+
+    def __init__(self, model_size: str = "base", diarize: bool = False, cache_dir: str = "transcripts"):
+        self.model_size = model_size
+        self.diarize = diarize
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def __call__(self, audio_path: str) -> Dict:
+        audio_path = str(audio_path)
+        cache_file = self.cache_dir / (Path(audio_path).stem + ".json")
+        if cache_file.exists():
+            with open(cache_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+        import whisperx
+        result = {}
+        model = whisperx.load_model(self.model_size, device=self.device, language="de")
+        transcription = model.transcribe(audio_path)
+        segments = transcription.get("segments", [])
+
+        if self.diarize:
+            token = os.getenv("HF_TOKEN")
+            diarize_model = whisperx.DiarizationPipeline(device=self.device, use_auth_token=token)
+            diarize_segments = diarize_model(audio_path)
+            segments = whisperx.assign_word_speakers(diarize_segments, transcription)["segments"]
+
+        result["audio_path"] = audio_path
+        result["segments"] = [
+            {
+                "text": s.get("text", ""),
+                "speaker": s.get("speaker", "Speaker"),
+                "start": float(s.get("start", 0.0)),
+                "end": float(s.get("end", 0.0)),
+            }
+            for s in segments
+        ]
+
+        with open(cache_file, "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+        torch.cuda.empty_cache()
+        return result

--- a/emotion_knowledge/db_emotion_annotator.py
+++ b/emotion_knowledge/db_emotion_annotator.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import torch
+from chromadb import PersistentClient
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+import torch.nn.functional as F
+
+
+class DBEmotionAnnotator:
+    """Annotate DB segments with emotions using a HF model."""
+
+    def __init__(
+        self,
+        db_path: str = "db",
+        model_name: str = "oliverguhr/german-emotion-bert",
+        batch_size: int = 8,
+        load_in_8bit: bool = False,
+    ):
+        self.client = PersistentClient(path=str(Path(db_path)))
+        self.collection = self.client.get_or_create_collection("segments")
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        kwargs = {"device_map": "auto"}
+        if load_in_8bit:
+            kwargs["load_in_8bit"] = True
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name, **kwargs)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model.to(device)
+        self.device = device
+        self.batch_size = batch_size
+        self.labels = [self.model.config.id2label[i] for i in range(self.model.config.num_labels)]
+
+    def _batch(self, items: List[str], size: int) -> List[List[str]]:
+        for i in range(0, len(items), size):
+            yield items[i : i + size]
+
+    def __call__(self, transcript: Dict) -> Dict:
+        data = self.collection.get(include=["metadatas", "documents", "ids"])
+        pending = [
+            (i, doc, meta)
+            for i, (doc, meta) in enumerate(zip(data["documents"], data["metadatas"]))
+            if meta is not None and "emotion" not in meta
+        ]
+        texts = [doc[:200] for _, doc, _ in pending]
+        ids = [data["ids"][i] for i, _, _ in pending]
+        results = {}
+        for batch_ids, batch_texts in zip(
+            [ids[i : i + self.batch_size] for i in range(0, len(ids), self.batch_size)],
+            self._batch(texts, self.batch_size),
+        ):
+            inputs = self.tokenizer(batch_texts, padding=True, truncation=True, return_tensors="pt").to(self.device)
+            with torch.no_grad():
+                logits = self.model(**inputs).logits
+                probs = F.softmax(logits, dim=-1)
+            emotions = [self.labels[p.argmax().item()] for p in probs]
+            for doc_id, emo in zip(batch_ids, emotions):
+                idx = ids.index(doc_id)
+                meta = data["metadatas"][idx]
+                meta["emotion"] = emo
+                self.collection.update(ids=[doc_id], metadatas=[meta])
+                results[doc_id] = emo
+            torch.cuda.empty_cache()
+        return transcript

--- a/emotion_knowledge/pipeline.py
+++ b/emotion_knowledge/pipeline.py
@@ -1,0 +1,27 @@
+from langchain_core.runnables import RunnableSequence
+
+from .audio_transcriber import AudioTranscriber
+from .segment_db_writer import SegmentDBWriter
+from .db_emotion_annotator import DBEmotionAnnotator
+from .transcript_formatter import TranscriptFormatter
+
+
+def emotion_transcription_pipeline(
+    diarize: bool = False,
+    model_size: str = "base",
+    emotion_model: str = "oliverguhr/german-emotion-bert",
+    db_path: str = "db",
+    clip_dir: str = "clips",
+    load_in_8bit: bool = False,
+    batch_size: int = 8,
+):
+    transcriber = AudioTranscriber(model_size=model_size, diarize=diarize)
+    writer = SegmentDBWriter(db_path=db_path, clip_dir=clip_dir)
+    annotator = DBEmotionAnnotator(
+        db_path=db_path,
+        model_name=emotion_model,
+        batch_size=batch_size,
+        load_in_8bit=load_in_8bit,
+    )
+    formatter = TranscriptFormatter()
+    return RunnableSequence(transcriber) | writer | annotator | formatter

--- a/emotion_knowledge/segment_db_writer.py
+++ b/emotion_knowledge/segment_db_writer.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+from chromadb import PersistentClient
+from pydub import AudioSegment
+
+
+class _ZeroEmbedding:
+    def __call__(self, input):
+        return [np.zeros(1)] * len(input)
+
+    def name(self):
+        return "zero"
+
+
+class SegmentDBWriter:
+    """Store transcript segments in ChromaDB and export audio clips."""
+
+    def __init__(self, db_path: str = "db", clip_dir: str = "clips"):
+        self.db_path = Path(db_path)
+        self.clip_dir = Path(clip_dir)
+        self.clip_dir.mkdir(parents=True, exist_ok=True)
+        self.client = PersistentClient(path=str(self.db_path))
+        self.collection = self.client.get_or_create_collection(
+            "segments", embedding_function=_ZeroEmbedding()
+        )
+
+    def __call__(self, transcript: Dict) -> Dict:
+        audio = AudioSegment.from_file(transcript["audio_path"])
+        for seg in transcript["segments"]:
+            seg_id = f"{Path(transcript['audio_path']).stem}-{int(seg['start']*1000)}-{int(seg['end']*1000)}"
+            existing = self.collection.get(ids=[seg_id])
+            if existing.get("ids"):
+                continue
+            clip_path = self.clip_dir / f"{seg_id}.wav"
+            if not clip_path.exists():
+                clip = audio[seg["start"] * 1000 : seg["end"] * 1000]
+                clip.export(clip_path, format="wav")
+            metadata = {
+                "speaker": seg.get("speaker"),
+                "start": seg.get("start"),
+                "end": seg.get("end"),
+                "audio": str(clip_path),
+            }
+            self.collection.add(
+                ids=[seg_id],
+                documents=[seg.get("text", "")],
+                metadatas=[metadata],
+                embeddings=[np.zeros(1)],
+            )
+        return transcript

--- a/emotion_knowledge/transcript_formatter.py
+++ b/emotion_knowledge/transcript_formatter.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+
+class TranscriptFormatter:
+    """Format annotated transcript segments."""
+
+    def __init__(self):
+        pass
+
+    def __call__(self, transcript: Dict) -> str:
+        lines = []
+        for seg in transcript.get("segments", []):
+            speaker = seg.get("speaker", "Speaker")
+            emotion = seg.get("emotion") or seg.get("metadata", {}).get("emotion")
+            if emotion is None:
+                emotion = "?"
+            lines.append(f"[{speaker}][{emotion}] {seg.get('text','').strip()}")
+        return "\n".join(lines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 transformers==4.38.2
 whisperx
+langchain-core==0.3.66
+chromadb==1.0.13
+pydub


### PR DESCRIPTION
## Summary
- add a new modular LangChain pipeline for German speech-to-emotion transcription
- store transcript segments in ChromaDB and clip audio
- annotate segments with a German emotion model
- format annotated transcript for display
- provide a CLI entry point and update docs

## Testing
- `python -m py_compile emotion_knowledge/audio_transcriber.py emotion_knowledge/segment_db_writer.py emotion_knowledge/db_emotion_annotator.py emotion_knowledge/transcript_formatter.py emotion_knowledge/pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e435a20a4832995b563849286403f