### PR TITLE
Add docs for emotion model argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ python -m emotion_knowledge path/to/audio.wav
 ```
 
 Use `--diarize` for speaker labels and `--load-in-8bit` to reduce GPU
-memory usage. All settings can be configured via command line:
+memory usage. All settings can be configured via command line. Pass
+`--emotion-model` to choose a different HuggingFace classifier:
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize --batch-size 16 \
     --db-path mydb --clip-dir clips
+```
+
+```bash
+python -m emotion_knowledge path/to/audio.wav --emotion-model arpanghoshal/EmoRoBERTa
 ```
 
 The script prints the emotion-enriched transcript to the console.


### PR DESCRIPTION
## Summary
- document the `--emotion-model` flag in the README for specifying a different HF classifier

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_685e48a001ec8329b7c68f055ad0511b