### PR TITLE
Gracefully handle missing segment timestamps

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -106,6 +106,8 @@ class WhisperXDiarizationWorkflow(Runnable):
         print(text)
 
         if segments:
+            # Log the first segment for easier debugging
+            print("First diarized segment:", segments[0])
             saver = SegmentSaver(db_path=db_path, output_dir=clip_dir)
             for segment in segments:
                 segment["audio_path"] = audio_path


### PR DESCRIPTION
## Summary
- make SegmentSaver tolerant of missing start/end keys
- log the first diarized segment in WhisperXDiarizationWorkflow for debugging

## Testing
- `python -m py_compile emotion_knowledge/segment_saver.py emotion_knowledge/__init__.py`
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled by user while downloading heavy packages)*

------
https://chatgpt.com/codex/tasks/task_e_685e9a7042608329a45226a0e281ae6b