### PR TITLE
Add ChromaDB export for diarized clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ Run a transcription:
 python -m emotion_knowledge path/to/audio.wav
 ```
 
-Add `--diarize` to enable speaker diarization with WhisperX:
+Add `--diarize` to enable speaker diarization with WhisperX. When diarization
+is enabled you can also store each speaker segment in a local ChromaDB
+instance by providing a database path and output directory for the audio
+clips. Each stored segment includes its speaker label, text and clip path:
 
 ```bash
-python -m emotion_knowledge path/to/audio.wav --diarize
+python -m emotion_knowledge path/to/audio.wav --diarize \
+    --db-path mydb --clip-dir clips
 ```
 
 The script prints the resulting transcription to the console.


### PR DESCRIPTION
## Summary
- return segments from `transcribe_diarize_whisperx`
- store diarized segments in Chroma using `SegmentSaver`
- allow setting `--db-path` and `--clip-dir`
- document new arguments in README
- fix missing text metadata for stored segments

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685e81ddf87c8329b1aec6c1fcd07169