### PR TITLE
Fix indentation issue in diarization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ is enabled you can also store each speaker segment in a local ChromaDB
 instance by providing a database path and output directory for the audio
 
 clips:
-ChromaDB-Implementation
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize \

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -110,7 +110,7 @@ class WhisperXDiarizationWorkflow(Runnable):
         if segments:
             # Log the first segment for easier debugging
             print("First diarized segment:", segments[0])
-        ChromaDB-Implementation
+        # ChromaDB-Implementation
             saver = SegmentSaver(db_path=db_path, output_dir=clip_dir)
             for segment in segments:
                 segment["audio_path"] = audio_path


### PR DESCRIPTION
## Summary
- remove extraneous placeholder line from README
- comment placeholder in `WhisperXDiarizationWorkflow` to avoid syntax errors

## Testing
- `python -m py_compile emotion_knowledge/__init__.py`
- `python -m emotion_knowledge emotion_knowledge/arena.wav --diarize` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_685ea22df4208329b3268e2c2e256a7e