### PR TITLE
Group diarized segments into utterances

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ python -m emotion_knowledge path/to/audio.wav
 ```
 
 Add `--diarize` to enable speaker diarization with WhisperX. When diarization
-is enabled you can also store each speaker segment in a local ChromaDB
-instance by providing a database path and output directory for the audio
-
-clips:
+is enabled you can also store each speaker **utterance** in a local ChromaDB
+instance by providing a database path and output directory for the audio clips.
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize \


### PR DESCRIPTION
## Summary
- group diarized words from WhisperX into full speaker utterances
- store grouped utterances in ChromaDB via `SegmentSaver`
- document utterance-level storage in README

## Testing
- `pip install -q -r requirements.txt` *(fails: fastapi depends on pydantic<2)*
- `python -m emotion_knowledge emotion_knowledge/arenaShort.wav --diarize --db-path tmpdb --clip-dir tmpclips` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_685fa08be40083298d47c93512e2740b