### PR TITLE
Fix segment order for utterance grouping

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -12,11 +12,10 @@ def _group_utterances(segments):
     if not segments:
         return []
 
-    # sort by start time to ensure chronological order
-    def _start(s):
-        return float(s.get("start", s.get("start_time", 0)))
-
-    segments = sorted(segments, key=_start)
+    # The word segments returned by WhisperX are already in chronological
+    # order. Sorting again can actually scramble the sequence if any words
+    # have slightly misaligned timestamps (e.g. negative values).  To preserve
+    # the diarization order we simply iterate over the provided list.
 
     grouped = []
     first_speaker = segments[0].get("speaker") or "speaker"


### PR DESCRIPTION
## Summary
- preserve WhisperX's ordering when grouping diarized word segments

## Testing
- `python -m py_compile emotion_knowledge/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685fefaf4e3083298e0807466072bbef