### PR TITLE
Add CLI option for WhisperX model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,8 @@ python -m emotion_knowledge path/to/audio.wav --diarize \
     --db-path mydb --clip-dir clips
 ```
 
+Use `--whisperx-model` to choose the WhisperX model size when diarization is
+enabled. The default is `medium`.
+
 The script prints the resulting transcription to the console.
 


### PR DESCRIPTION
## Summary
- allow choosing WhisperX model size via command line
- document new `--whisperx-model` option in README

## Testing
- `python -m emotion_knowledge -h | head -n 20` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_685ff9f65a288329ab92d47449db479c