### PR TITLE
Fix utterance end times when grouping WhisperX segments

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -25,7 +25,10 @@ def _group_utterances(segments, max_gap: float = 0.7):
     norm_segments = []
     for seg in segments:
         start = float(seg.get("start", seg.get("start_time", 0)))
-        end = float(seg.get("end", seg.get("end_time", 0)))
+        end_val = seg.get("end")
+        if (end_val is None or float(end_val) == 0.0) and "end_time" in seg:
+            end_val = seg.get("end_time")
+        end = float(end_val if end_val is not None else 0)
         norm_segments.append(
             {
                 "speaker": seg.get("speaker") or "speaker",
@@ -48,7 +51,7 @@ def _group_utterances(segments, max_gap: float = 0.7):
         gap = seg["start"] - current["end"]
         if seg["speaker"] == current["speaker"] and gap <= max_gap:
             current["text"] += " " + seg["text"]
-            current["end"] = seg["end"]
+            current["end"] = seg.get("end", seg.get("end_time", current["end"]))
         else:
             grouped.append(current)
             current = seg.copy()

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from emotion_knowledge import _group_utterances
+
+
+def test_grouping_updates_end_time():
+    segments = [
+        {"speaker": "speaker_01", "start": 0.0, "end_time": 0.5, "word": "Hallo"},
+        {"speaker": "speaker_01", "start": 0.5, "end": 1.0, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(0.0)
+    assert result[0]["end"] == pytest.approx(1.0)
+    assert result[0]["text"] == "Hallo Welt"
+
+
+def test_single_word_has_end_time():
+    segments = [
+        {"speaker": "speaker_02", "start": 1.5, "end_time": 2.0, "word": "Test"}
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(1.5)
+    assert result[0]["end"] == pytest.approx(2.0)
+    assert result[0]["text"] == "Test"
+


### PR DESCRIPTION
## Summary
- handle both `end` and `end_time` keys when normalizing WhisperX output
- update grouping logic to always set the end time from the last word
- add tests for `_group_utterances`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f811649083299804fa4d47a30821