### PR TITLE
Add end_time fix utility

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -5,6 +5,7 @@ from langchain_core.tools import tool
 import whisper
 
 from .segment_saver import SegmentSaver
+from .fix_end_times import fix_end_times
 
 
 def _group_utterances(segments, max_gap: float = 0.7):

--- a/emotion_knowledge/fix_end_times.py
+++ b/emotion_knowledge/fix_end_times.py
@@ -1,0 +1,49 @@
+import argparse
+import os
+import pandas as pd
+import soundfile as sf
+
+
+def fix_end_times(csv_path: str, output_path: str = None) -> str:
+    """Update rows where ``end_time`` is zero using the audio clip duration.
+
+    Parameters
+    ----------
+    csv_path : str
+        Path to the CSV file containing at least ``start_time``, ``end_time``
+        and ``audio_clip_path`` columns.
+    output_path : str, optional
+        Where to write the updated CSV. Defaults to ``segments_fixed.csv`` in
+        the same directory as ``csv_path``.
+
+    Returns
+    -------
+    str
+        Path to the written CSV file.
+    """
+    df = pd.read_csv(csv_path)
+
+    if output_path is None:
+        directory, name = os.path.split(csv_path)
+        output_path = os.path.join(directory, "segments_fixed.csv")
+
+    for idx, row in df[df.get("end_time", 0) == 0].iterrows():
+        audio_file = row.get("audio_clip_path")
+        if not audio_file or not os.path.exists(audio_file):
+            continue
+        with sf.SoundFile(audio_file) as f:
+            duration = len(f) / f.samplerate
+        df.loc[idx, "end_time"] = row["start_time"] + duration
+
+    df.to_csv(output_path, index=False)
+    return output_path
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fix zero end_time values in a segments CSV")
+    parser.add_argument("csv", help="Path to segments CSV")
+    parser.add_argument("-o", "--output", default=None, help="Output CSV path")
+    args = parser.parse_args()
+
+    result = fix_end_times(args.csv, args.output)
+    print(f"Wrote updated segments to {result}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ whisperx
 langchain-core
 chromadb
 pydub
+pandas
+soundfile


### PR DESCRIPTION
## Summary
- add a script to repair zero end_time values using the audio clip's length
- expose new utility from package init
- include pandas and soundfile in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_686117c6725c8329968b28a8f19ecf07