### PR TITLE
Fix utterance end times when diarization data missing

### DIFF
--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -28,3 +28,15 @@ def test_single_word_has_end_time():
     assert result[0]["end"] == pytest.approx(2.0)
     assert result[0]["text"] == "Test"
 
+
+def test_zero_end_time_is_filled():
+    segments = [
+        {"speaker": "speaker_01", "start": 0.0, "end_time": 0.0, "word": "Hallo"},
+        {"speaker": "speaker_01", "start": 0.5, "end": 1.0, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(0.0)
+    assert result[0]["end"] == pytest.approx(1.0)
+    assert result[0]["text"] == "Hallo Welt"
+


### PR DESCRIPTION
## Summary
- make optional imports for dependencies so tests don't fail
- ensure `_group_utterances` infers end times when missing/zero
- update diarization workflow to error if SegmentSaver unavailable
- add regression test for zero end times

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611d2a36e48329935d04d2d33ba4fe