### PR TITLE
Fix utterance end times using next start

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -81,6 +81,13 @@ def _group_utterances(segments, max_gap: float = 0.7):
             current = seg.copy()
 
     grouped.append(current)
+
+    # extend each utterance to start of the following one so the audio clip
+    # fully contains the spoken words even if WhisperX produced short end
+    # timestamps.  The final utterance keeps its original end time.
+    for i in range(len(grouped) - 1):
+        grouped[i]["end"] = grouped[i + 1]["start"]
+
     return grouped
 
 

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -40,3 +40,14 @@ def test_zero_end_time_is_filled():
     assert result[0]["end"] == pytest.approx(1.0)
     assert result[0]["text"] == "Hallo Welt"
 
+
+def test_end_time_extended_to_next_start():
+    segments = [
+        {"speaker": "speaker_01", "start": 0.0, "end": 1.0, "word": "Hallo"},
+        {"speaker": "speaker_01", "start": 5.0, "end": 5.5, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 2
+    # end of first utterance should match start of second
+    assert result[0]["end"] == pytest.approx(result[1]["start"])
+


### PR DESCRIPTION
## Summary
- modify `_group_utterances` so each utterance's end aligns with the next start
- add regression test covering the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656fde876c832998d3d43a38fdc1df