### PR TITLE
Improve interruption grouping heuristic

### DIFF
--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -51,3 +51,47 @@ def test_end_time_extended_to_next_start():
     # end of first utterance should match start of second
     assert result[0]["end"] == pytest.approx(result[1]["start"])
 
+
+def test_short_interjection_is_merged():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
+        {"speaker": "s2", "start": 0.5, "end": 0.6, "word": "hm"},
+        {"speaker": "s1", "start": 0.6, "end": 1.0, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(0.0)
+    assert result[0]["end"] == pytest.approx(1.0)
+    assert result[0]["text"] == "Hallo hm Welt"
+
+
+def test_long_single_word_interjection_is_merged():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
+        {"speaker": "s2", "start": 0.5, "end": 1.4, "word": "hm"},
+        {"speaker": "s1", "start": 1.4, "end": 2.0, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(0.0)
+    assert result[0]["end"] == pytest.approx(2.0)
+    assert result[0]["text"] == "Hallo hm Welt"
+
+
+def test_multi_word_interjection_over_one_second_not_merged():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
+        {
+            "speaker": "s2",
+            "start": 0.5,
+            "end": 1.7,
+            "text": "ach so",
+        },
+        {"speaker": "s1", "start": 1.7, "end": 2.2, "word": "Welt"},
+    ]
+    result = _group_utterances(segments)
+    assert len(result) == 3
+    assert result[0]["text"] == "Hallo"
+    assert result[1]["text"] == "ach so"
+    assert result[2]["text"] == "Welt"
+


### PR DESCRIPTION
## Summary
- broaden short-interjection detection to allow 1s pauses or single-word interruptions
- adapt merging logic to tolerate longer gaps
- expand unit tests for longer and multi-word interruptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657e3db9c48329b0e6f35e42595612