### PR TITLE
Add multimodal emotion tagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ multimodal approaches.
 The code is structured so additional components can be inserted, such as
 an audio-based emotion model.
 
+## Multimodal emotion tagging
+
+`MultimodalEmotionTagger` combines a text classifier and a speech emotion
+recognition model.  The class loads two Hugging Face pipelines – one for
+`text-classification` and one for `audio-classification`.  By default it uses
+models that understand German.  The predicted emotion label can be stored in a
+database column named `Emotion_Text`.
+
 ## Default models
 
 The built-in classes work with German data. `AudioTranscriber` uses
@@ -37,6 +45,17 @@ Run a transcription:
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav
+```
+
+To enrich the results with an emotion label based on both the transcribed text
+and the original audio you can load ``MultimodalEmotionTagger`` in your own
+notebook or script:
+
+```python
+from emotion_knowledge.emotion_tagger import MultimodalEmotionTagger
+tagger = MultimodalEmotionTagger()
+emotion = tagger.invoke(text, "path/to/audio.wav")
+db["Emotion_Text"] = emotion
 ```
 
 Add `--diarize` to enable speaker diarization with WhisperX. When diarization

--- a/emotion_knowledge/emotion_tagger.py
+++ b/emotion_knowledge/emotion_tagger.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+from transformers import pipeline
+
+class MultimodalEmotionTagger:
+    """Predict emotion from both text and audio input."""
+
+    def __init__(
+        self,
+        text_model: str = "oliverguhr/german-sentiment-bert",
+        audio_model: str = "speechbrain/emotion-recognition-wav2vec2",
+    ) -> None:
+        self.text_classifier = pipeline("text-classification", model=text_model)
+        self.audio_classifier = pipeline("audio-classification", model=audio_model)
+
+    def _prob_dict(self, outputs: List[Dict[str, float]]) -> Dict[str, float]:
+        prob = {}
+        for out in outputs:
+            label = out.get("label")
+            score = out.get("score", 0.0)
+            prob[label] = prob.get(label, 0.0) + score
+        return prob
+
+    def invoke(self, text: str, audio_path: str) -> str:
+        text_res = self.text_classifier(text)
+        audio_res = self.audio_classifier(audio_path)
+        t_probs = self._prob_dict(text_res)
+        a_probs = self._prob_dict(audio_res)
+        all_labels = set(t_probs) | set(a_probs)
+        combo = {}
+        for label in all_labels:
+            combo[label] = t_probs.get(label, 0.0) + a_probs.get(label, 0.0)
+        if not combo:
+            return ""
+        return max(combo, key=combo.get)
+
+


### PR DESCRIPTION
## Summary
- implement `MultimodalEmotionTagger` for text + audio emotion classification
- document multimodal tagging in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686643858fc48329b852c6923d5e70e2