### PR TITLE
Switch to logging

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -1,5 +1,9 @@
 import argparse
 import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 try:
     from langchain_core.runnables import Runnable
@@ -146,8 +150,8 @@ def transcribe_diarize_whisperx(audio_path: str, model_size: str = "medium"):
         result["segments"], align_model, metadata, audio_path, device=device
     )
     word_segments = aligned_output["word_segments"]
-    print(type(word_segments))
-    print(word_segments[:2])  # Now it's safe to preview
+    logger.debug(type(word_segments))
+    logger.debug(word_segments[:2])  # Now it's safe to preview
 
     token = os.getenv("HF_TOKEN")  # set this in Colab/terminal
     diarize_model = whisperx.DiarizationPipeline(device=device, use_auth_token=token)
@@ -203,8 +207,7 @@ class TranscriptionOnlyWorkflow(Runnable):
 
     def invoke(self, audio_path: str) -> str:
         text = transcribe_audio_whisper.invoke(audio_path)
-        print("📄 Transkribierter Text:\n")
-        print(text)
+        logger.info("\ud83d\udcc4 Transkribierter Text:\n%s", text)
         return text
 
 
@@ -231,12 +234,11 @@ class WhisperXDiarizationWorkflow(Runnable):
             text = str(result)
             segments = []
 
-        print("📄 Transkription mit Sprecherlabels:\n")
-        print(text)
+        logger.info("\ud83d\udcc4 Transkription mit Sprecherlabels:\n%s", text)
 
         if segments:
             # Log the first segment for easier debugging
-            print("First diarized segment:", segments[0])
+            logger.debug("First diarized segment: %s", segments[0])
             if SegmentSaver is None:
                 raise ImportError("SegmentSaver requires optional dependencies")
             saver = SegmentSaver(db_path=db_path, output_dir=clip_dir)

--- a/emotion_knowledge/segment_saver.py
+++ b/emotion_knowledge/segment_saver.py
@@ -5,6 +5,9 @@ from typing import Any, Dict
 from langchain_core.runnables import Runnable
 from pydub import AudioSegment
 import chromadb
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class SegmentSaver(Runnable):
@@ -20,7 +23,7 @@ class SegmentSaver(Runnable):
         """Slice the audio segment and store its metadata."""
         audio_path = segment.get("audio_path")
         if not audio_path or not os.path.exists(audio_path):
-            print("Audio path missing or invalid for segment", segment)
+            logger.warning("Audio path missing or invalid for segment %s", segment)
             return {}
 
         # WhisperX may produce either "start"/"end" or "start_time"/"end_time".
@@ -31,14 +34,14 @@ class SegmentSaver(Runnable):
             start_val = segment["start_time"]
             end_val = segment["end_time"]
         else:
-            print("Skipping segment due to missing time keys", list(segment.keys()))
+            logger.warning("Skipping segment due to missing time keys %s", list(segment.keys()))
             return {}
 
         try:
             start_ms = max(0, int(float(start_val) * 1000))
             end_ms = max(start_ms, int(float(end_val) * 1000))
         except Exception as exc:
-            print("Invalid start/end values", start_val, end_val, exc)
+            logger.error("Invalid start/end values %s %s %s", start_val, end_val, exc)
             return {}
 
         speaker = segment.get("speaker", "speaker").lower()
@@ -49,7 +52,13 @@ class SegmentSaver(Runnable):
         audio[start_ms:end_ms].export(clip_path, format="wav")
 
         duration_ms = end_ms - start_ms
-        print(f"Saved clip {clip_path} ({duration_ms} ms) speaker={speaker} text='{segment.get('text','')}'")
+        logger.info(
+            "Saved clip %s (%d ms) speaker=%s text='%s'",
+            clip_path,
+            duration_ms,
+            speaker,
+            segment.get("text", ""),
+        )
 
         doc_id = uuid.uuid4().hex
         metadata = {

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -1,6 +1,10 @@
 import os
 import sys
+import logging
 import pytest
+
+# Silence package logs during tests
+logging.disable(logging.CRITICAL)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from emotion_knowledge import _group_utterances


### PR DESCRIPTION
## Summary
- add logging setup to `emotion_knowledge`
- log important messages in `segment_saver` and workflows
- silence logging during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686653304c88832982053b39f9962ebf