### PR TITLE
Update README for new emotion tagging workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,27 @@ multimodal approaches.
 
 ## Overview
 
-1. **AudioTranscriber** – converts an audio file to text using the
-   Hugging Face `transformers` ASR pipeline (Whisper).
-2. **TextEmotionAnnotator** – prompts a Llama model to label the emotion
-   of the text.
-3. **EmotionTranscriptionPipeline** – orchestrates the two steps. It
-   returns both the plain transcription and the emotion-enriched text.
-
-The code is structured so additional components can be inserted, such as
-an audio-based emotion model.
+EmotionKnowledge offers a CLI workflow for German speech transcription.
+It can optionally run speaker diarization and store each utterance in a
+database.  The package also provides a `MultimodalEmotionTagger` for
+predicting emotions from text and the corresponding audio.
 
 ## Multimodal emotion tagging
 
 `MultimodalEmotionTagger` combines a text classifier and a speech emotion
 recognition model.  The class loads two Hugging Face pipelines – one for
-`text-classification` and one for `audio-classification`.  By default it uses
-models that understand German.  The predicted emotion label can be stored in a
-database column named `Emotion_Text`.
+`text-classification` and one for `audio-classification`.  By default it
+uses the text model `oliverguhr/german-sentiment-bert` and the audio model
+`superb/wav2vec2-base-superb-er`.  The predicted emotion label can be stored
+in a database column named `Emotion_Text`.
 
 ## Default models
 
-The built-in classes work with German data. `AudioTranscriber` uses
-`openai/whisper-base` for speech recognition and passes
-`language='de'` when invoking the pipeline. `TextEmotionAnnotator` uses
-``meta-llama/Meta-Llama-3-8B-Instruct`` to generate a single emotion
-label.
+`MultimodalEmotionTagger` automatically loads
+`oliverguhr/german-sentiment-bert` for text classification and
+`superb/wav2vec2-base-superb-er` for speech emotion recognition.  The
+transcription workflow relies on `openai/whisper-base` to convert German
+audio to text.
 
 ## Usage
 
@@ -58,9 +54,11 @@ emotion = tagger.invoke(text, "path/to/audio.wav")
 db["Emotion_Text"] = emotion
 ```
 
-Add `--diarize` to enable speaker diarization with WhisperX. When diarization
-is enabled you can also store each speaker **utterance** in a local ChromaDB
-instance by providing a database path and output directory for the audio clips.
+Add `--diarize` to enable speaker diarization with WhisperX using the
+`WhisperXDiarizationWorkflow`.  When diarization is enabled you can also
+store each speaker **utterance** in a local ChromaDB instance via
+`SegmentSaver` by providing a database path and output directory for the
+audio clips.
 
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize \


### PR DESCRIPTION
## Summary
- remove references to deprecated classes
- document `MultimodalEmotionTagger` defaults
- note diarization and segment saving via `WhisperXDiarizationWorkflow` and `SegmentSaver`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686652fe1f98832996a24d16abd6131c