### PR TITLE
Add audio emotion annotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ uses the text model `oliverguhr/german-sentiment-bert` and the audio model
 `superb/wav2vec2-base-superb-er`.  The predicted emotion label can be stored
 in a database column named `Emotion_Text`.
 
+An additional `AudioEmotionAnnotator` is available to annotate existing
+utterances purely based on their audio clips. It uses the Hugging Face model
+`superb/hubert-large-superb-er` and stores the label in a new field
+`emotion_annotated_text`.
+
 ## Default models
 
 `MultimodalEmotionTagger` automatically loads

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -27,6 +27,12 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     SegmentSaver = None
 
+try:
+    from .audio_emotion_annotator import AudioEmotionAnnotator, annotate_chromadb
+except Exception:  # pragma: no cover - optional dependency
+    AudioEmotionAnnotator = None
+    annotate_chromadb = None
+
 
 def _group_utterances(segments, max_gap: float = 0.7):
     """Merge word-level segments into full utterances.

--- a/emotion_knowledge/audio_emotion_annotator.py
+++ b/emotion_knowledge/audio_emotion_annotator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import os
+from typing import Dict, Any
+
+from langchain_core.runnables import Runnable
+from transformers import pipeline
+
+
+class AudioEmotionAnnotator(Runnable):
+    """Annotate utterances with the dominant emotion from audio."""
+
+    def __init__(self, model_name: str = "superb/hubert-large-superb-er") -> None:
+        self.classifier = pipeline("audio-classification", model=model_name)
+        self.label_map = {
+            "angry": "Wut",
+            "anger": "Wut",
+            "sad": "Traurigkeit",
+            "sadness": "Traurigkeit",
+            "happy": "Freude",
+            "happiness": "Freude",
+            "surprise": "Überraschung",
+            "fear": "Angst",
+            "disgust": "Ekel",
+            "calm": "Gelassenheit",
+            "neutral": "Neutral",
+        }
+
+    def invoke(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        audio_path = entry.get("audio_clip_path")
+        text = entry.get("text", "")
+        label = "Neutral"
+        if audio_path and os.path.exists(audio_path):
+            result = self.classifier(audio_path)
+            if result:
+                label = result[0]["label"]
+                label = self.label_map.get(label.lower(), label)
+        entry["emotion_annotated_text"] = f"[{label}] {text}".strip()
+        return entry
+
+
+def annotate_chromadb(db_path: str, collection_name: str = "segments") -> None:
+    """Add emotion_annotated_text to each entry in a ChromaDB collection."""
+    import chromadb
+
+    annotator = AudioEmotionAnnotator()
+    client = chromadb.PersistentClient(path=db_path)
+    collection = client.get_or_create_collection(collection_name)
+    result = collection.get(include=["metadatas", "documents", "ids"])
+    metadatas = result.get("metadatas", [])
+    ids = result.get("ids", [])
+    documents = result.get("documents", [])
+    new_metas = []
+    for meta, doc in zip(metadatas, documents):
+        entry = meta.copy()
+        entry["text"] = doc
+        entry = annotator.invoke(entry)
+        meta["emotion_annotated_text"] = entry["emotion_annotated_text"]
+        new_metas.append(meta)
+    if ids:
+        collection.update(ids=ids, metadatas=new_metas)


### PR DESCRIPTION
## Summary
- add `AudioEmotionAnnotator` runnable for classifying emotions from audio clips
- expose the annotator in the package API
- document the feature in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_6866650c18988329a439061b0476b798