### PR TITLE
Refactor audio emotion annotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ uses the text model `oliverguhr/german-sentiment-bert` and the audio model
 in your own data store, for example in a column named `Emotion_Text`.
 
 An additional `AudioEmotionAnnotator` is available to annotate existing
-utterances purely based on their audio clips. It uses the Hugging Face model
-`superb/hubert-large-superb-er` and stores the label in a new field
-`emotion_annotated_text`.
+utterances purely based on their audio clips. It now wraps an emotion model
+and by default loads `padmalcom/wav2vec2-large-emotion-detection-german`.
+The predicted label is added to a new field `emotion_annotated_text`.
 
 ## Default models
 
 `MultimodalEmotionTagger` automatically loads
 `oliverguhr/german-sentiment-bert` for text classification and
 `superb/wav2vec2-base-superb-er` for speech emotion recognition.  The
-transcription workflow uses the open-source Whisper model (base size) to
+`AudioEmotionAnnotator` uses `padmalcom/wav2vec2-large-emotion-detection-german`.
+The transcription workflow uses the open-source Whisper model (base size) to
 convert German audio to text.
 
 ## Usage

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -33,6 +33,12 @@ except Exception:  # pragma: no cover - optional dependency
     AudioEmotionAnnotator = None
     annotate_chromadb = None
 
+try:
+    from .emotion_models import EmotionModel, MultimodalEmotionModel
+except Exception:  # pragma: no cover - optional dependency
+    EmotionModel = None
+    MultimodalEmotionModel = None
+
 
 def _group_utterances(segments, max_gap: float = 0.7):
     """Merge word-level segments into full utterances.

--- a/emotion_knowledge/emotion_models.py
+++ b/emotion_knowledge/emotion_models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from transformers import pipeline
+
+
+class EmotionModel:
+    """Wrapper around a Hugging Face audio-classification pipeline."""
+
+    def __init__(self, model_name: str = "padmalcom/wav2vec2-large-emotion-detection-german") -> None:
+        # load from local cache if available, no auth token required
+        self.classifier = pipeline("audio-classification", model=model_name)
+
+    def predict(self, audio_path: str) -> str:
+        """Return the top emotion label for the given audio file."""
+        result = self.classifier(audio_path)
+        if result:
+            return result[0].get("label", "")
+        return ""
+
+
+class MultimodalEmotionModel:
+    """Simple fusion of an audio and text emotion model."""
+
+    def __init__(
+        self,
+        audio_model: EmotionModel,
+        text_classifier,
+        neutral_label: str = "neutral",
+    ) -> None:
+        self.audio_model = audio_model
+        self.text_classifier = text_classifier
+        self.neutral_label = neutral_label.lower()
+
+    def predict(self, audio_path: str, text: str) -> str:
+        audio_label = self.audio_model.predict(audio_path)
+        text_label = ""
+        if text:
+            text_res = self.text_classifier(text)
+            if text_res:
+                text_label = text_res[0].get("label", "")
+
+        if audio_label and audio_label.lower() != self.neutral_label:
+            return audio_label
+        return text_label or audio_label

--- a/tests/test_audio_emotion_annotator.py
+++ b/tests/test_audio_emotion_annotator.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from emotion_knowledge.audio_emotion_annotator import AudioEmotionAnnotator
+from emotion_knowledge.emotion_models import EmotionModel
+
+
+class FakeModel(EmotionModel):
+    def __init__(self):
+        pass
+
+    def predict(self, audio_path: str) -> str:  # type: ignore[override]
+        FakeModel.called_with = audio_path
+        return "anger"
+
+
+def test_audio_annotator_uses_injected_model(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "exists", lambda p: True)
+    model = FakeModel()
+    annotator = AudioEmotionAnnotator(emotion_model=model)
+    entry = {"audio_clip_path": str(tmp_path / "audio.wav"), "text": "Hallo"}
+    result = annotator.invoke(entry)
+    assert result["emotion_annotated_text"] == "[Wut] Hallo"
+    assert FakeModel.called_with == entry["audio_clip_path"]
+


### PR DESCRIPTION
## Summary
- implement `EmotionModel` and `MultimodalEmotionModel`
- refactor `AudioEmotionAnnotator` to use `EmotionModel`
- switch default model to `padmalcom/wav2vec2-large-emotion-detection-german`
- expose emotion models in package `__init__`
- document new annotator behaviour in README
- add tests for injected model behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686679a756b08329b02b32338908de0c