### PR TITLE
Remove German mapping from emotion annotator

### DIFF
--- a/emotion_knowledge/audio_emotion_annotator.py
+++ b/emotion_knowledge/audio_emotion_annotator.py
@@ -16,19 +16,8 @@ class AudioEmotionAnnotator(Runnable):
         label_map: Optional[Dict[str, str]] = None,
     ) -> None:
         self.emotion_model = emotion_model or EmotionModel()
-        self.label_map = label_map or {
-            "angry": "Wut",
-            "anger": "Wut",
-            "sad": "Traurigkeit",
-            "sadness": "Traurigkeit",
-            "happy": "Freude",
-            "happiness": "Freude",
-            "surprise": "Überraschung",
-            "fear": "Angst",
-            "disgust": "Ekel",
-            "calm": "Gelassenheit",
-            "neutral": "Neutral",
-        }
+        # keep an optional label_map for compatibility, but default to no mapping
+        self.label_map = label_map or {}
 
     def invoke(self, entry: Dict[str, Any]) -> Dict[str, Any]:
         audio_path = entry.get("audio_clip_path")

--- a/tests/test_audio_emotion_annotator.py
+++ b/tests/test_audio_emotion_annotator.py
@@ -22,6 +22,6 @@ def test_audio_annotator_uses_injected_model(monkeypatch, tmp_path):
     annotator = AudioEmotionAnnotator(emotion_model=model)
     entry = {"audio_clip_path": str(tmp_path / "audio.wav"), "text": "Hallo"}
     result = annotator.invoke(entry)
-    assert result["emotion_annotated_text"] == "[Wut] Hallo"
+    assert result["emotion_annotated_text"] == "[anger] Hallo"
     assert FakeModel.called_with == entry["audio_clip_path"]
 


### PR DESCRIPTION
## Summary
- simplify `AudioEmotionAnnotator` by dropping the English→German label translation
- update tests to expect raw emotion labels

## Testing
- `pip install langchain-core pydub transformers chromadb -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866884de7508329987d9a6a1ded0973