### PR TITLE
Add emotion confidence column

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ in your own data store, for example in a column named `Emotion_Text`.
 An additional `AudioEmotionAnnotator` is available to annotate existing
 utterances purely based on their audio clips. It now wraps an emotion model
 and by default loads `padmalcom/wav2vec2-large-emotion-detection-german`.
-The predicted label is added to a new field `emotion_annotated_text`.
+The predicted label is added to a new field `emotion_annotated_text` and the
+model's confidence score is stored in `emotion_confidence`.
 
 ## Default models
 

--- a/emotion_knowledge/emotion_models.py
+++ b/emotion_knowledge/emotion_models.py
@@ -10,12 +10,15 @@ class EmotionModel:
         # load from local cache if available, no auth token required
         self.classifier = pipeline("audio-classification", model=model_name)
 
-    def predict(self, audio_path: str) -> str:
-        """Return the top emotion label for the given audio file."""
+    def predict(self, audio_path: str) -> tuple[str, float]:
+        """Return the top emotion label and confidence for the given audio file."""
         result = self.classifier(audio_path)
         if result:
-            return result[0].get("label", "")
-        return ""
+            top = result[0]
+            label = top.get("label", "")
+            score = float(top.get("score", 0.0))
+            return label, score
+        return "", 0.0
 
 
 class MultimodalEmotionModel:
@@ -32,7 +35,7 @@ class MultimodalEmotionModel:
         self.neutral_label = neutral_label.lower()
 
     def predict(self, audio_path: str, text: str) -> str:
-        audio_label = self.audio_model.predict(audio_path)
+        audio_label, _ = self.audio_model.predict(audio_path)
         text_label = ""
         if text:
             text_res = self.text_classifier(text)

--- a/tests/test_audio_emotion_annotator.py
+++ b/tests/test_audio_emotion_annotator.py
@@ -3,6 +3,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import pytest
+
 from emotion_knowledge.audio_emotion_annotator import AudioEmotionAnnotator
 from emotion_knowledge.emotion_models import EmotionModel
 
@@ -11,9 +13,9 @@ class FakeModel(EmotionModel):
     def __init__(self):
         pass
 
-    def predict(self, audio_path: str) -> str:  # type: ignore[override]
+    def predict(self, audio_path: str) -> tuple[str, float]:  # type: ignore[override]
         FakeModel.called_with = audio_path
-        return "anger"
+        return "anger", 0.85
 
 
 def test_audio_annotator_uses_injected_model(monkeypatch, tmp_path):
@@ -23,5 +25,6 @@ def test_audio_annotator_uses_injected_model(monkeypatch, tmp_path):
     entry = {"audio_clip_path": str(tmp_path / "audio.wav"), "text": "Hallo"}
     result = annotator.invoke(entry)
     assert result["emotion_annotated_text"] == "[anger] Hallo"
+    assert result["emotion_confidence"] == pytest.approx(0.85)
     assert FakeModel.called_with == entry["audio_clip_path"]
 


### PR DESCRIPTION
## Summary
- expose the score from `EmotionModel.predict`
- store the confidence in `AudioEmotionAnnotator`
- update `annotate_chromadb` accordingly
- document the new metadata field in README
- update tests for the new return value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_6867c9abd3188329853f2f935302d215