### PR TITLE
Add fallback for Runnable import

### DIFF
--- a/emotion_knowledge/audio_emotion_annotator.py
+++ b/emotion_knowledge/audio_emotion_annotator.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 import os
 from typing import Dict, Any, Optional
 
-from langchain_core.runnables import Runnable
+try:
+    from langchain_core.runnables import Runnable
+except Exception:  # pragma: no cover - optional dependency
+    class Runnable:  # minimal fallback so tests can import module
+        def invoke(self, *args, **kwargs):  # pragma: no cover - not used in tests
+            raise ImportError("langchain-core is required for this feature")
 
 from .emotion_models import EmotionModel
 

--- a/emotion_knowledge/segment_saver.py
+++ b/emotion_knowledge/segment_saver.py
@@ -2,7 +2,12 @@ import os
 import uuid
 from typing import Any, Dict
 
-from langchain_core.runnables import Runnable
+try:
+    from langchain_core.runnables import Runnable
+except Exception:  # pragma: no cover - optional dependency
+    class Runnable:  # minimal fallback so tests can import module
+        def invoke(self, *args, **kwargs):  # pragma: no cover - not used in tests
+            raise ImportError("langchain-core is required for this feature")
 from pydub import AudioSegment
 import chromadb
 import logging


### PR DESCRIPTION
## Summary
- support environments without langchain-core by adding a minimal `Runnable` fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d0810ac08329b06c71fe95bbed85