### PR TITLE
Add text-based emotion detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,19 @@ and by default loads `padmalcom/wav2vec2-large-emotion-detection-german`.
 The predicted label is added to a new field `emotion_annotated_text` and the
 model's confidence score is stored in `emotion_confidence`.
 
+For text-only emotion detection the package offers `TextEmotionAnnotator`
+which uses a German BERT model. It adds the fields `text_emotion_label` and
+`text_emotion_confidence` to an entry while leaving any existing audio based
+emotion information untouched.
+
 ## Default models
 
 `MultimodalEmotionTagger` automatically loads
 `oliverguhr/german-sentiment-bert` for text classification and
 `superb/wav2vec2-base-superb-er` for speech emotion recognition.  The
 `AudioEmotionAnnotator` uses `padmalcom/wav2vec2-large-emotion-detection-german`.
+`TextEmotionAnnotator` defaults to `oliverguhr/german-emotion-bert` for
+classifying emotions in text.
 The transcription workflow uses the open-source Whisper model (base size) to
 convert German audio to text.
 

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -34,10 +34,20 @@ except Exception:  # pragma: no cover - optional dependency
     annotate_chromadb = None
 
 try:
-    from .emotion_models import EmotionModel, MultimodalEmotionModel
+    from .emotion_models import (
+        EmotionModel,
+        MultimodalEmotionModel,
+        TextEmotionModel,
+    )
 except Exception:  # pragma: no cover - optional dependency
     EmotionModel = None
     MultimodalEmotionModel = None
+    TextEmotionModel = None
+
+try:
+    from .text_emotion_annotator import TextEmotionAnnotator
+except Exception:  # pragma: no cover - optional dependency
+    TextEmotionAnnotator = None
 
 
 def _group_utterances(segments, max_gap: float = 0.7):

--- a/emotion_knowledge/emotion_models.py
+++ b/emotion_knowledge/emotion_models.py
@@ -21,6 +21,23 @@ class EmotionModel:
         return "", 0.0
 
 
+class TextEmotionModel:
+    """Wrapper around a text-classification pipeline for emotion detection."""
+
+    def __init__(self, model_name: str = "oliverguhr/german-emotion-bert") -> None:
+        self.classifier = pipeline("text-classification", model=model_name)
+
+    def predict(self, text: str) -> tuple[str, float]:
+        """Return the top emotion label and confidence for the given text."""
+        result = self.classifier(text)
+        if result:
+            top = result[0]
+            label = top.get("label", "")
+            score = float(top.get("score", 0.0))
+            return label, score
+        return "", 0.0
+
+
 class MultimodalEmotionModel:
     """Simple fusion of an audio and text emotion model."""
 

--- a/emotion_knowledge/text_emotion_annotator.py
+++ b/emotion_knowledge/text_emotion_annotator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Any, Dict, Optional
+
+try:
+    from langchain_core.runnables import Runnable
+except Exception:  # pragma: no cover - optional dependency
+    class Runnable:  # minimal fallback so tests can import module
+        def invoke(self, *args, **kwargs):  # pragma: no cover - not used in tests
+            raise ImportError("langchain-core is required for this feature")
+
+from .emotion_models import TextEmotionModel
+
+
+class TextEmotionAnnotator(Runnable):
+    """Annotate utterances with an emotion label predicted from text."""
+
+    def __init__(
+        self,
+        emotion_model: Optional[TextEmotionModel] = None,
+        label_map: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.emotion_model = emotion_model or TextEmotionModel()
+        self.label_map = label_map or {}
+
+    def invoke(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        text = entry.get("text", "")
+        label = ""
+        confidence = 0.0
+        if text:
+            raw_label, confidence = self.emotion_model.predict(text)
+            if raw_label:
+                label = self.label_map.get(raw_label.lower(), raw_label)
+        entry["text_emotion_label"] = label
+        entry["text_emotion_confidence"] = confidence
+        return entry

--- a/tests/test_text_emotion_annotator.py
+++ b/tests/test_text_emotion_annotator.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from emotion_knowledge.text_emotion_annotator import TextEmotionAnnotator
+from emotion_knowledge.emotion_models import TextEmotionModel
+
+
+class FakeTextModel(TextEmotionModel):
+    def __init__(self):
+        pass
+
+    def predict(self, text: str) -> tuple[str, float]:  # type: ignore[override]
+        FakeTextModel.called_with = text
+        return "Freude", 0.92
+
+
+def test_text_emotion_annotator_keeps_other_fields():
+    entry = {
+        "text": "Hallo Welt",
+        "emotion_annotated_text": "[anger] Hallo Welt",
+        "emotion_confidence": 0.5,
+    }
+    annotator = TextEmotionAnnotator(emotion_model=FakeTextModel())
+    result = annotator.invoke(entry)
+    assert result["text_emotion_label"] == "Freude"
+    assert result["text_emotion_confidence"] == pytest.approx(0.92)
+    assert result["emotion_annotated_text"] == "[anger] Hallo Welt"
+    assert result["emotion_confidence"] == pytest.approx(0.5)
+    assert FakeTextModel.called_with == entry["text"]


### PR DESCRIPTION
## Summary
- add `TextEmotionModel` and `TextEmotionAnnotator` for predicting emotions from text
- document the new annotator and default model
- expose new classes in package init
- test `TextEmotionAnnotator` functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870adffd810832984440efa01c267a4