### PR TITLE
Fix text emotion model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ emotion information untouched.
 `oliverguhr/german-sentiment-bert` for text classification and
 `superb/wav2vec2-base-superb-er` for speech emotion recognition.  The
 `AudioEmotionAnnotator` uses `padmalcom/wav2vec2-large-emotion-detection-german`.
-`TextEmotionAnnotator` defaults to `oliverguhr/german-emotion-bert` for
+`TextEmotionAnnotator` defaults to `oliverguhr/german-sentiment-bert` for
 classifying emotions in text.
 The transcription workflow uses the open-source Whisper model (base size) to
 convert German audio to text.

--- a/emotion_knowledge/emotion_models.py
+++ b/emotion_knowledge/emotion_models.py
@@ -24,7 +24,7 @@ class EmotionModel:
 class TextEmotionModel:
     """Wrapper around a text-classification pipeline for emotion detection."""
 
-    def __init__(self, model_name: str = "oliverguhr/german-emotion-bert") -> None:
+    def __init__(self, model_name: str = "oliverguhr/german-sentiment-bert") -> None:
         self.classifier = pipeline("text-classification", model=model_name)
 
     def predict(self, text: str) -> tuple[str, float]:


### PR DESCRIPTION
## Summary
- fix default text model to use `oliverguhr/german-sentiment-bert`
- update README to match

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b505276483299a8e4d42019f491a