### PR TITLE
Separate audio emotion label and transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ in your own data store, for example in a column named `Emotion_Text`.
 An additional `AudioEmotionAnnotator` is available to annotate existing
 utterances purely based on their audio clips. It now wraps an emotion model
 and by default loads `padmalcom/wav2vec2-large-emotion-detection-german`.
-The predicted label is added to a new field `emotion_annotated_text` and the
-model's confidence score is stored in `emotion_confidence`.
+The predicted label is stored in `audio_emotion_label` and the model's
+confidence score in `audio_emotion_confidence`. The transcribed text is kept
+in a separate field `audio_text`.
 
 For text-only emotion detection the package offers `TextEmotionAnnotator`
 which uses a German BERT model. It adds the fields `text_emotion_label` and

--- a/tests/test_audio_emotion_annotator.py
+++ b/tests/test_audio_emotion_annotator.py
@@ -24,7 +24,8 @@ def test_audio_annotator_uses_injected_model(monkeypatch, tmp_path):
     annotator = AudioEmotionAnnotator(emotion_model=model)
     entry = {"audio_clip_path": str(tmp_path / "audio.wav"), "text": "Hallo"}
     result = annotator.invoke(entry)
-    assert result["emotion_annotated_text"] == "[anger] Hallo"
-    assert result["emotion_confidence"] == pytest.approx(0.85)
+    assert result["audio_emotion_label"] == "anger"
+    assert result["audio_emotion_confidence"] == pytest.approx(0.85)
+    assert result["audio_text"] == "Hallo"
     assert FakeModel.called_with == entry["audio_clip_path"]
 

--- a/tests/test_text_emotion_annotator.py
+++ b/tests/test_text_emotion_annotator.py
@@ -21,13 +21,15 @@ class FakeTextModel(TextEmotionModel):
 def test_text_emotion_annotator_keeps_other_fields():
     entry = {
         "text": "Hallo Welt",
-        "emotion_annotated_text": "[anger] Hallo Welt",
-        "emotion_confidence": 0.5,
+        "audio_emotion_label": "anger",
+        "audio_emotion_confidence": 0.5,
+        "audio_text": "Hallo Welt",
     }
     annotator = TextEmotionAnnotator(emotion_model=FakeTextModel())
     result = annotator.invoke(entry)
     assert result["text_emotion_label"] == "Freude"
     assert result["text_emotion_confidence"] == pytest.approx(0.92)
-    assert result["emotion_annotated_text"] == "[anger] Hallo Welt"
-    assert result["emotion_confidence"] == pytest.approx(0.5)
+    assert result["audio_emotion_label"] == "anger"
+    assert result["audio_emotion_confidence"] == pytest.approx(0.5)
+    assert result["audio_text"] == "Hallo Welt"
     assert FakeTextModel.called_with == entry["text"]


### PR DESCRIPTION
## Summary
- refactor `AudioEmotionAnnotator` to output `audio_emotion_label`,
  `audio_emotion_confidence` and `audio_text`
- update ChromaDB helper to store the new fields
- adjust tests for new output
- document updated keys in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ca517ac083298e93ffb7ceb85fb1