### PR TITLE
Add segment-based grouping to utterance helper

### DIFF
--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -99,3 +99,13 @@ def test_multi_word_interjection_over_one_second_not_merged():
     assert result[1]["text"] == "ach so"
     assert result[2]["text"] == "Welt"
 
+
+def test_same_segment_id_overrides_gap():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo", "segment": 0},
+        {"speaker": "s1", "start": 2.0, "end": 2.5, "word": "Welt", "segment": 0},
+    ]
+    result = _group_utterances(segments, max_gap=0.1)
+    assert len(result) == 1
+    assert result[0]["text"] == "Hallo Welt"
+


### PR DESCRIPTION
## Summary
- keep segment index for each word returned by `transcribe_diarize_whisperx`
- support segment-based merging in `_group_utterances`
- extend diarization workflow to pass segment info
- test grouping words with identical segment ids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b375cf288329a46ddcd7a5a14496