### PR TITLE
Improve audio clip trimming

### DIFF
--- a/emotion_knowledge/emotion_models.py
+++ b/emotion_knowledge/emotion_models.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from transformers import pipeline
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency
+    def pipeline(*args, **kwargs):  # type: ignore[override]
+        raise ImportError("transformers is required for this feature")
 
 
 class EmotionModel:

--- a/emotion_knowledge/segment_saver.py
+++ b/emotion_knowledge/segment_saver.py
@@ -9,7 +9,16 @@ except Exception:  # pragma: no cover - optional dependency
         def invoke(self, *args, **kwargs):  # pragma: no cover - not used in tests
             raise ImportError("langchain-core is required for this feature")
 from pydub import AudioSegment
-import chromadb
+from pydub.silence import detect_nonsilent
+try:
+    import chromadb
+except Exception:  # pragma: no cover - optional dependency
+    class _MissingChroma:  # minimal stub so tests can patch PersistentClient
+        class PersistentClient:
+            def __init__(self, *args, **kwargs):
+                raise ImportError("chromadb is required for this feature")
+
+    chromadb = _MissingChroma()
 import logging
 
 logger = logging.getLogger(__name__)
@@ -18,11 +27,20 @@ logger = logging.getLogger(__name__)
 class SegmentSaver(Runnable):
     """Save diarized segments to disk and ChromaDB."""
 
-    def __init__(self, collection_name: str = "segments", db_path: str = "segment_db", output_dir: str = "clips") -> None:
+    def __init__(
+        self,
+        collection_name: str = "segments",
+        db_path: str = "segment_db",
+        output_dir: str = "clips",
+        end_buffer_ms: int = 50,
+        trim_silence: bool = True,
+    ) -> None:
         self.output_dir = output_dir
         os.makedirs(self.output_dir, exist_ok=True)
         self.client = chromadb.PersistentClient(path=db_path)
         self.collection = self.client.get_or_create_collection(collection_name)
+        self.end_buffer_ms = max(0, int(end_buffer_ms))
+        self.trim_silence = trim_silence
 
     def invoke(self, segment: Dict[str, Any]) -> Dict[str, Any]:
         """Slice the audio segment and store its metadata."""
@@ -54,7 +72,25 @@ class SegmentSaver(Runnable):
         clip_path = os.path.join(self.output_dir, clip_name)
 
         audio = AudioSegment.from_file(audio_path)
-        audio[start_ms:end_ms].export(clip_path, format="wav")
+        clip = audio[start_ms:end_ms]
+
+        if self.end_buffer_ms and len(clip) > self.end_buffer_ms:
+            clip = clip[:-self.end_buffer_ms]
+
+        if self.trim_silence:
+            try:
+                nonsilent = detect_nonsilent(
+                    clip,
+                    min_silence_len=150,
+                    silence_thresh=clip.dBFS - 30,
+                )
+                if nonsilent:
+                    start_trim, end_trim = nonsilent[0][0], nonsilent[-1][1]
+                    clip = clip[start_trim:end_trim]
+            except Exception as exc:  # pragma: no cover - silence detection optional
+                logger.debug("Silence trimming failed: %s", exc)
+
+        clip.export(clip_path, format="wav")
 
         duration_ms = end_ms - start_ms
         logger.info(


### PR DESCRIPTION
## Summary
- allow optional dependencies for tests
- trim silence from saved clips and add buffer before exporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68790df07c848329bf5e5f145b74d7a1