### PR TITLE
Add optional sentence-level merging for diarized utterances

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ store each speaker **utterance** in a local ChromaDB instance via
 `SegmentSaver` by providing a database path and output directory for the
 audio clips.
 
+When grouping words into utterances you can enable sentence-level grouping by
+merging consecutive utterances from the same speaker. The helper function
+`_group_utterances` now accepts `merge_sentences=True` to perform this merge and
+the diarization workflow uses this option by default so each saved clip contains
+full sentences per speaker.
+
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize \
     --db-path mydb --clip-dir clips

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -50,7 +50,12 @@ except Exception:  # pragma: no cover - optional dependency
     TextEmotionAnnotator = None
 
 
-def _group_utterances(segments, max_gap: float = 0.7, segments_info=None):
+def _group_utterances(
+    segments,
+    max_gap: float = 0.7,
+    segments_info=None,
+    merge_sentences: bool = False,
+):
     """Merge word-level segments into full utterances.
 
     Parameters
@@ -60,6 +65,9 @@ def _group_utterances(segments, max_gap: float = 0.7, segments_info=None):
     max_gap : float
         Maximum allowed pause between words (in seconds) for them to be
         merged into the same utterance.
+    merge_sentences : bool, optional
+        When ``True`` merge consecutive utterances from the same speaker into a
+        single entry. This is useful for sentence-level grouping.
     """
 
     if not segments:
@@ -135,6 +143,16 @@ def _group_utterances(segments, max_gap: float = 0.7, segments_info=None):
                 }
             )
 
+        if merge_sentences and grouped:
+            merged = [grouped[0].copy()]
+            for utt in grouped[1:]:
+                if utt["speaker"] == merged[-1]["speaker"]:
+                    merged[-1]["text"] += " " + utt["text"]
+                    merged[-1]["end"] = utt["end"]
+                else:
+                    merged.append(utt.copy())
+            grouped = merged
+
         for i in range(len(grouped) - 1):
             grouped[i]["end"] = grouped[i + 1]["start"]
 
@@ -197,6 +215,15 @@ def _group_utterances(segments, max_gap: float = 0.7, segments_info=None):
         i += 1
 
     grouped.append(current)
+    if merge_sentences and grouped:
+        merged = [grouped[0].copy()]
+        for utt in grouped[1:]:
+            if utt["speaker"] == merged[-1]["speaker"]:
+                merged[-1]["text"] += " " + utt["text"]
+                merged[-1]["end"] = utt["end"]
+            else:
+                merged.append(utt.copy())
+        grouped = merged
 
     # extend each utterance to start of the following one so the audio clip
     # fully contains the spoken words even if WhisperX produced short end
@@ -362,7 +389,9 @@ class WhisperXDiarizationWorkflow(Runnable):
             saver = SegmentSaver(db_path=db_path, output_dir=clip_dir)
             logger.info("Grouping diarized words into utterances")
             utterances = _group_utterances(
-                segments, segments_info=result.get("segments_info")
+                segments,
+                segments_info=result.get("segments_info"),
+                merge_sentences=True,
             )
             logger.info("Saving %d utterances to %s", len(utterances), clip_dir)
             for idx, utt in enumerate(utterances, 1):

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -109,3 +109,15 @@ def test_same_segment_id_overrides_gap():
     assert len(result) == 1
     assert result[0]["text"] == "Hallo Welt"
 
+
+def test_merge_sentences_combines_same_speaker():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 1.0, "word": "Hallo"},
+        {"speaker": "s1", "start": 3.0, "end": 4.0, "word": "Welt"},
+    ]
+    result = _group_utterances(segments, merge_sentences=True)
+    assert len(result) == 1
+    assert result[0]["start"] == pytest.approx(0.0)
+    assert result[0]["end"] == pytest.approx(4.0)
+    assert result[0]["text"] == "Hallo Welt"
+


### PR DESCRIPTION
## Summary
- allow `_group_utterances` to merge consecutive same-speaker entries via new `merge_sentences` flag
- use sentence merging in `WhisperXDiarizationWorkflow`
- document `merge_sentences` option in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924ac8944c8329b1ca433db2b2c46f