### PR TITLE
Pass WhisperX model size through workflow and add CLI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ python -m emotion_knowledge path/to/audio.wav --diarize \
 ```
 
 Use `--whisperx-model` to choose the WhisperX model size when diarization is
-enabled. The default is `medium`.
+enabled. The default is `medium`, but you can also select `base`, `small`, or
+`large` depending on your resource constraints.
+
+For example, the following command uses the smaller `base` model:
+
+```bash
+python -m emotion_knowledge path/to/audio.wav --diarize --whisperx-model base
+```
 
 The script prints the resulting transcription to the console.
 

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -372,7 +372,7 @@ class WhisperXDiarizationWorkflow(Runnable):
         model_size: str = "medium",
     ) -> str:
         logger.info("Transcribing and diarizing %s", audio_path)
-        result = transcribe_diarize_whisperx.invoke(audio_path, model_size=model_size)
+        result = transcribe_diarize_whisperx(audio_path, model_size=model_size)
         if isinstance(result, dict):
             text = result.get("text", "")
             segments = result.get("segments", [])

--- a/tests/test_cli_whisperx_model.py
+++ b/tests/test_cli_whisperx_model.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import logging
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import emotion_knowledge
+
+
+def test_cli_whisperx_model_base(monkeypatch, tmp_path, caplog):
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"")
+
+    def fake_transcribe(audio_path: str, model_size: str = "medium"):
+        emotion_knowledge.logger.info(
+            "Starting WhisperX transcription using model '%s'", model_size
+        )
+        return {"text": "", "segments": []}
+
+    monkeypatch.setattr(emotion_knowledge, "transcribe_diarize_whisperx", fake_transcribe)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(audio_file),
+            "--diarize",
+            "--whisperx-model",
+            "base",
+        ],
+    )
+
+    with caplog.at_level(logging.INFO, logger="emotion_knowledge"):
+        emotion_knowledge.main()
+
+    assert "Starting WhisperX transcription using model 'base'" in caplog.text


### PR DESCRIPTION
## Summary
- Pass selected WhisperX model size from `WhisperXDiarizationWorkflow` directly to `transcribe_diarize_whisperx`
- Document `--whisperx-model` flag and show how to run with the `base` model
- Add unit test confirming CLI uses the specified WhisperX model size

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ef5522dc832985c04db46299da17