### PR TITLE
Preserve real speaker interruptions in utterance grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ merging consecutive utterances from the same speaker. The helper function
 the diarization workflow uses this option by default so each saved clip contains
 full sentences per speaker.
 
+By default real interruptions from another speaker are preserved as their own
+utterances. You can disable this healing with ``--no-keep-interruptions`` on the
+CLI, which will merge short interjections back into the surrounding speech.
+
 ```bash
 python -m emotion_knowledge path/to/audio.wav --diarize \
     --db-path mydb --clip-dir clips


### PR DESCRIPTION
## Summary
- add `keep_interjections` option to `_group_utterances` to keep real speaker changes as distinct utterances
- expose `--keep-interruptions/--no-keep-interruptions` CLI flag and thread through workflow
- refine segment-id grouping and end-time snapping to avoid collapsing interjections or truncating overlaps
- add unit tests for interruptions, segment-id splits, and overlapping timestamps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ffad5d7c8329af2ed91752ffafb4