### PR TITLE
Add CLI max-gap option for WhisperX diarization

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -423,6 +423,7 @@ class WhisperXDiarizationWorkflow(Runnable):
         clip_dir: str = "clips",
         model_size: str = "medium",
         keep_interjections: bool = True,
+        max_gap: float = 0.7,
         language: str = "de",
         compute_type: str = "int8",
         beam_size: int = 5,
@@ -462,6 +463,7 @@ class WhisperXDiarizationWorkflow(Runnable):
             logger.info("Grouping diarized words into utterances")
             utterances = _group_utterances(
                 segments,
+                max_gap=max_gap,
                 segments_info=result.get("segments_info"),
                 merge_sentences=True,
                 keep_interjections=keep_interjections,
@@ -507,6 +509,12 @@ def main():
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Preserve short interruptions as separate utterances (default on)",
+    )
+    parser.add_argument(
+        "--max-gap",
+        type=float,
+        default=0.7,
+        help="Maximum allowed pause between words for same utterance",
     )
     parser.add_argument(
         "--language",
@@ -558,6 +566,7 @@ def main():
             clip_dir=args.clip_dir,
             model_size=args.whisperx_model,
             keep_interjections=args.keep_interruptions,
+            max_gap=args.max_gap,
             language=args.language,
             compute_type=args.compute_type,
             beam_size=args.beam_size,

--- a/tests/test_cli_whisperx_model.py
+++ b/tests/test_cli_whisperx_model.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -38,3 +39,47 @@ def test_cli_whisperx_model_base(monkeypatch, tmp_path, caplog):
         emotion_knowledge.main()
 
     assert "Starting WhisperX transcription using model 'base'" in caplog.text
+
+
+def test_cli_max_gap_forwarded(monkeypatch, tmp_path):
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"")
+
+    class FakeTranscribe:
+        def invoke(self, params):
+            return {"text": "", "segments": [{"speaker": "s1", "start": 0.0, "end": 0.5}]}
+
+    class FakeSaver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def invoke(self, *args, **kwargs):
+            pass
+
+    captured = {}
+
+    def fake_group(seg, max_gap=0.7, **kwargs):
+        captured["max_gap"] = max_gap
+        return []
+
+    monkeypatch.setattr(
+        emotion_knowledge, "transcribe_diarize_whisperx", FakeTranscribe()
+    )
+    monkeypatch.setattr(emotion_knowledge, "SegmentSaver", FakeSaver)
+    monkeypatch.setattr(emotion_knowledge, "_group_utterances", fake_group)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(audio_file),
+            "--diarize",
+            "--max-gap",
+            "1.23",
+        ],
+    )
+
+    emotion_knowledge.main()
+
+    assert captured["max_gap"] == pytest.approx(1.23)


### PR DESCRIPTION
## Summary
- allow configuring utterance grouping gap via `max_gap` in `WhisperXDiarizationWorkflow`
- expose `--max-gap` option in CLI
- test CLI forwards gap value to grouping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68960cf0babc832987e5a73424feffca