### PR TITLE
Handle unsupported WhisperX transcribe args

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -296,6 +296,7 @@ def transcribe_diarize_whisperx(
     """
     import torch
     import whisperx
+    import inspect
 
     assert os.path.exists(audio_path), f"Datei nicht gefunden: {audio_path}"
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -307,9 +308,16 @@ def transcribe_diarize_whisperx(
         language=language,
         compute_type=compute_type,
     )
-    result = model.transcribe(
-        audio_path, beam_size=beam_size, temperature=temperature
-    )
+    transcribe_params = inspect.signature(model.transcribe).parameters
+    kwargs = {
+        name: val
+        for name, val in {
+            "beam_size": beam_size,
+            "temperature": temperature,
+        }.items()
+        if name in transcribe_params
+    }
+    result = model.transcribe(audio_path, **kwargs)
     logger.info("Transcription complete with %d segments", len(result.get("segments", [])))
 
     align_model, metadata = whisperx.load_align_model(


### PR DESCRIPTION
## Summary
- Guard WhisperX transcription call by checking `FasterWhisperPipeline.transcribe` signature
- Only forward `beam_size` and `temperature` when supported by installed WhisperX version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689615424adc8329baf403ee87d451ec