### PR TITLE
Add word-level transcript export with CSV fallback

### DIFF
--- a/tests/test_export_word_level_excel.py
+++ b/tests/test_export_word_level_excel.py
@@ -1,0 +1,42 @@
+import os
+
+import pandas as pd
+import pytest
+
+from emotion_knowledge import export_word_level_excel
+
+
+def test_export_word_level_excel_fallback_csv(tmp_path, monkeypatch):
+    words = [
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.4, "text": "hi"},
+        {"segment": 1, "speaker": "B", "start": 0.5, "end": 0, "text": "there"},
+    ]
+
+    def raise_import_error(*args, **kwargs):
+        raise ImportError("openpyxl missing")
+
+    monkeypatch.setattr(pd.DataFrame, "to_excel", raise_import_error)
+    out = tmp_path / "Single_Word_Transcript.xlsx"
+    path = export_word_level_excel(words, str(out))
+
+    assert path.endswith(".csv")
+    assert os.path.exists(path)
+
+    df = pd.read_csv(path)
+    assert list(df.columns) == [
+        "idx",
+        "segment",
+        "speaker",
+        "start",
+        "end",
+        "duration",
+        "text",
+        "is_backchannel",
+    ]
+    # missing end timestamp should fallback to start
+    assert df.loc[1, "end"] == pytest.approx(df.loc[1, "start"])
+    # duration column should be max(0, end-start)
+    assert df.loc[0, "duration"] == pytest.approx(
+        df.loc[0, "end"] - df.loc[0, "start"]
+    )
+


### PR DESCRIPTION
## Summary
- add `export_word_level_excel` helper to save raw word segments with backchannel tagging
- expose optional `--export-words-xlsx` flag to control export and wire into diarization workflow
- cover export behavior with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897079ce8748329b6805701dcb9a591