### PR TITLE
Preserve utterance end times based on last word

### DIFF
--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -56,14 +56,15 @@ def test_end_time_preserved_by_default():
     assert result[0]["end"] == pytest.approx(1.0)
 
 
-def test_end_time_extended_when_disabled():
+def test_end_time_not_modified_when_disabled():
     segments = [
         {"speaker": "speaker_01", "start": 0.0, "end": 1.0, "word": "Hallo"},
         {"speaker": "speaker_01", "start": 5.0, "end": 5.5, "word": "Welt"},
     ]
     result = _group_utterances(segments, preserve_end_times=False)
     assert len(result) == 2
-    assert result[0]["end"] == pytest.approx(result[1]["start"])
+    # end timestamps come from the final word regardless of preserve_end_times
+    assert result[0]["end"] == pytest.approx(1.0)
 
 
 def test_short_interjection_becomes_backchannel():


### PR DESCRIPTION
## Summary
- stop extending utterance end times to the next utterance
- derive start/end of each utterance strictly from its first and last word
- adjust tests for new timing behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897154fa7688329b49e2458b5672c01