### PR TITLE
feat: auto-select WhisperX compute type

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ python -m emotion_knowledge path/to/audio.wav --diarize \
 
 Use `--whisperx-model` to choose the WhisperX model size when diarization is
 enabled. The default is `medium`, but you can also select `base`, `small`, or
-`large` depending on your resource constraints.
+`large` depending on your resource constraints. The workflow automatically
+selects the compute type: `float16` when a CUDA-enabled GPU is available and
+`int8` otherwise, logging the chosen precision for transparency.
 
 Short backchannel interjections are preserved as separate utterances. Pass
 `--no-preserve-backchannels` to merge them back into the surrounding speech. Use

--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -382,9 +382,16 @@ def transcribe_diarize_whisperx(audio_path: str, model_size: str = "medium"):
 
     assert os.path.exists(audio_path), f"Datei nicht gefunden: {audio_path}"
     device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    logger.info("Starting WhisperX transcription using model '%s'", model_size)
-    model = whisperx.load_model(model_size, device=device, language="de", compute_type="int8")
+    compute_type = "float16" if device == "cuda" else "int8"
+    logger.info(
+        "Starting WhisperX transcription using model '%s' with compute type '%s' on %s",
+        model_size,
+        compute_type,
+        device,
+    )
+    model = whisperx.load_model(
+        model_size, device=device, language="de", compute_type=compute_type
+    )
     result = model.transcribe(audio_path)
     logger.info("Transcription complete with %d segments", len(result.get("segments", [])))
 


### PR DESCRIPTION
## Summary
- detect CUDA availability to select WhisperX compute type
- log chosen precision and document behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897270555dc832994c8790470a549dd