### PR TITLE
Allow custom diarization models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Use `--whisperx-model` to choose the WhisperX model size when diarization is
 enabled. The default is `medium`, but you can also select `base`, `small`, or
 `large` depending on your resource constraints.
 
+To experiment with different speaker diarization backends, provide a Hugging Face
+model ID via `--diarization-model`. The default is
+`pyannote/speaker-diarization-3.1`, but any compatible model can be used. For
+example, to try the `mistralai/Voxtral-Small-24B-2507` model:
+
+```bash
+python -m emotion_knowledge path/to/audio.wav --diarize \
+    --diarization-model mistralai/Voxtral-Small-24B-2507
+```
+
 For example, the following command uses the smaller `base` model:
 
 ```bash

--- a/tests/test_cli_diarization_model.py
+++ b/tests/test_cli_diarization_model.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import logging
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import emotion_knowledge
+
+
+def test_cli_diarization_model(monkeypatch, tmp_path, caplog):
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"")
+
+    class FakeTranscribe:
+        def invoke(self, params):
+            model = params.get("diarization_model")
+            emotion_knowledge.logger.info("Using diarization model '%s'", model)
+            return {"text": "", "segments": []}
+
+    monkeypatch.setattr(
+        emotion_knowledge, "transcribe_diarize_whisperx", FakeTranscribe()
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(audio_file),
+            "--diarize",
+            "--diarization-model",
+            "mistralai/Voxtral-Small-24B-2507",
+        ],
+    )
+
+    with caplog.at_level(logging.INFO, logger="emotion_knowledge"):
+        emotion_knowledge.main()
+
+    assert (
+        "Using diarization model 'mistralai/Voxtral-Small-24B-2507'" in caplog.text
+    )


### PR DESCRIPTION
## Summary
- allow providing a custom Hugging Face diarization model id
- surface diarization model option in workflow and CLI
- document diarization model usage and add CLI test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973ceba3508329b0e03688a4e682ca