### PR TITLE
feat: allow configuring whisper temperature via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Run a transcription:
 python -m emotion_knowledge path/to/audio.wav
 ```
 
+Use the ``--temperature`` flag to control the sampling temperature of the
+Whisper model (default ``0.3``):
+
+```bash
+python -m emotion_knowledge path/to/audio.wav --temperature 0.7
+```
+
 `WhisperXDiarizationWorkflow`.  When diarization is enabled you can also
 store each speaker **utterance** in a local ChromaDB instance via
 `SegmentSaver` by providing a database path and output directory for the

--- a/tests/test_cli_temperature.py
+++ b/tests/test_cli_temperature.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import emotion_knowledge
+
+
+def test_cli_sets_temperature(monkeypatch, tmp_path):
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"")
+
+    class FakeTranscribe:
+        def invoke(self, params):
+            assert params.get("temperature") == 0.7
+            return ""
+
+    monkeypatch.setattr(
+        emotion_knowledge, "transcribe_audio_whisper", FakeTranscribe()
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["prog", str(audio_file), "--temperature", "0.7"]
+    )
+
+    emotion_knowledge.main()
+


### PR DESCRIPTION
## Summary
- add `--temperature` CLI flag to control Whisper sampling temperature
- pass temperature through transcription workflows
- document new flag and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68975532b9708329a3bb7fa0e2772a4e