### PR TITLE
Replace WhisperX diarization with Sortformer model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers==4.38.2
-whisperx
 langchain-core
 chromadb
 pydub
+nemo_toolkit[asr]

--- a/tests/test_cli_sortformer_model.py
+++ b/tests/test_cli_sortformer_model.py
@@ -7,20 +7,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import emotion_knowledge
 
 
-def test_cli_whisperx_model_base(monkeypatch, tmp_path, caplog):
+def test_cli_sortformer_model(tmp_path, monkeypatch, caplog):
     audio_file = tmp_path / "audio.wav"
     audio_file.write_bytes(b"")
 
     class FakeTranscribe:
         def invoke(self, params):
-            model_size = params.get("model_size", "medium")
+            model_name = params.get("model_name", "nvidia/diar_sortformer_4spk-v1")
             emotion_knowledge.logger.info(
-                "Starting WhisperX transcription using model '%s'", model_size
+                "Loading Sortformer diarization model '%s'", model_name
             )
             return {"text": "", "segments": []}
 
     monkeypatch.setattr(
-        emotion_knowledge, "transcribe_diarize_whisperx", FakeTranscribe()
+        emotion_knowledge, "transcribe_diarize_sortformer", FakeTranscribe()
     )
     monkeypatch.setattr(
         sys,
@@ -29,12 +29,12 @@ def test_cli_whisperx_model_base(monkeypatch, tmp_path, caplog):
             "prog",
             str(audio_file),
             "--diarize",
-            "--whisperx-model",
-            "base",
+            "--sortformer-model",
+            "local_model",
         ],
     )
 
     with caplog.at_level(logging.INFO, logger="emotion_knowledge"):
         emotion_knowledge.main()
 
-    assert "Starting WhisperX transcription using model 'base'" in caplog.text
+    assert "Loading Sortformer diarization model 'local_model'" in caplog.text


### PR DESCRIPTION
## Summary
- switch diarization workflow to NVIDIA's Sortformer diarizer and expose `--sortformer-model` CLI flag
- document Sortformer architecture, installation and usage
- update tests for new diarizer option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68984a63d4e48329adcd45d620d53a0f