### PR TITLE
Ensure diarization stats computed with segment info

### DIFF
--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -168,3 +168,21 @@ def test_utterance_statistics_and_overlap():
     assert second["n_words"] == 1
     assert second["mean_word_gap"] == pytest.approx(0.0)
 
+
+def test_stats_with_segments_info():
+    segments = [
+        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "hello", "segment": 0},
+        {"speaker": "s1", "start": 0.8, "end": 1.0, "word": "there", "segment": 0},
+        {"speaker": "s2", "start": 1.5, "end": 2.0, "word": "hey", "segment": 1},
+    ]
+    result = _group_utterances(segments, segments_info=[{}, {}])
+    assert len(result) == 2
+    first, second = result
+    assert first["n_words"] == 2
+    assert first["duration"] == pytest.approx(1.0)
+    assert first["words_per_sec"] == pytest.approx(2.0)
+    assert first["mean_word_gap"] == pytest.approx(0.3)
+    assert first["p95_word_gap"] == pytest.approx(0.3)
+    assert second["n_words"] == 1
+    assert second["duration"] == pytest.approx(0.5)
+


### PR DESCRIPTION
## Summary
- compute utterance statistics even when `segments_info` is provided to `_group_utterances`
- test that segment-id diarization yields duration and gap metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c545d534832995aebe8efbd7258f