### PR TITLE
Add database reset option

### DIFF
--- a/emotion_knowledge/__main__.py
+++ b/emotion_knowledge/__main__.py
@@ -1,4 +1,41 @@
-from . import main
+"""Command line entry point for :mod:`emotion_knowledge`.
+
+Provides a ``--reset-db`` flag that clears the persistent Chroma database
+before delegating to :func:`emotion_knowledge.main`.
+
+Example
+-------
+>>> python -m emotion_knowledge --reset-db <audiofile>
+"""
+
+import argparse
+import sys
+
+from . import main as pkg_main
+
+
+def run() -> None:
+    """Run the command line interface.
+
+    ``--reset-db`` clears the saved ChromaDB collections before invoking the
+    standard :func:`emotion_knowledge.main` workflow.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--reset-db",
+        action="store_true",
+        help="Reset the ChromaDB database before processing",
+    )
+    args, remaining = parser.parse_known_args()
+
+    if args.reset_db:
+        from .segment_saver import SegmentSaver
+
+        SegmentSaver().reset_db()
+
+    sys.argv = [sys.argv[0]] + remaining
+    pkg_main()
+
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/emotion_knowledge/segment_saver.py
+++ b/emotion_knowledge/segment_saver.py
@@ -25,7 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 class SegmentSaver(Runnable):
-    """Save diarized segments to disk and ChromaDB."""
+    """Save diarized segments to disk and ChromaDB.
+
+    Call :meth:`reset_db` to clear the underlying Chroma database.  This can
+    also be triggered from the command line via ``python -m emotion_knowledge
+    --reset-db``.
+    """
 
     def __init__(
         self,
@@ -123,3 +128,14 @@ class SegmentSaver(Runnable):
             documents=[metadata["text"]], metadatas=[metadata], ids=[doc_id]
         )
         return {"clip_path": clip_path, "speaker": speaker, "doc_id": doc_id}
+
+    def reset_db(self) -> None:
+        """Reset the underlying ChromaDB instance.
+
+        Removes all collections using :meth:`chromadb.PersistentClient.reset`.
+        Useful for cleaning up between runs or tests.  The same operation can be
+        invoked from the command line with ``python -m emotion_knowledge
+        --reset-db``.
+        """
+
+        self.client.reset()

--- a/tests/test_multimodal_emotion_tagger.py
+++ b/tests/test_multimodal_emotion_tagger.py
@@ -20,9 +20,13 @@ class FakeClient:
     def __init__(self, path):
         self.path = path
         self.collection = FakeCollection()
+        self.reset_called = False
 
     def get_or_create_collection(self, name):
         return self.collection
+
+    def reset(self):
+        self.reset_called = True
 
 
 def test_segment_saver_saves_audio_and_metadata(monkeypatch, tmp_path):
@@ -59,4 +63,15 @@ def test_segment_saver_saves_audio_and_metadata(monkeypatch, tmp_path):
     assert metas[0]["duration"] == pytest.approx(0.5)
     assert metas[0]["n_words"] == 1
     assert metas[0]["overlaps_started"] is False
+
+
+def test_segment_saver_reset_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "emotion_knowledge.segment_saver.chromadb.PersistentClient",
+        FakeClient,
+    )
+
+    saver = SegmentSaver(db_path=str(tmp_path / "db"), output_dir=str(tmp_path))
+    saver.reset_db()
+    assert saver.client.reset_called
 


### PR DESCRIPTION
## Summary
- add `SegmentSaver.reset_db` for clearing ChromaDB collections
- add `--reset-db` CLI option to purge the database prior to running
- test reset behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898decc1a8c83299b3cd987a40b1362