### PR TITLE
Add allow_reset option for safe ChromaDB resets

### DIFF
--- a/emotion_knowledge/__main__.py
+++ b/emotion_knowledge/__main__.py
@@ -1,7 +1,9 @@
 """Command line entry point for :mod:`emotion_knowledge`.
 
 Provides a ``--reset-db`` flag that clears the persistent Chroma database
-before delegating to :func:`emotion_knowledge.main`.
+before delegating to :func:`emotion_knowledge.main`.  The reset operation
+requires an explicit opt-in and will construct the underlying client with
+``allow_reset=True``.
 
 Example
 -------
@@ -31,7 +33,7 @@ def run() -> None:
     if args.reset_db:
         from .segment_saver import SegmentSaver
 
-        SegmentSaver().reset_db()
+        SegmentSaver(allow_reset=True).reset_db()
 
     sys.argv = [sys.argv[0]] + remaining
     pkg_main()

--- a/emotion_knowledge/segment_saver.py
+++ b/emotion_knowledge/segment_saver.py
@@ -14,6 +14,10 @@ try:
     import chromadb
 except Exception:  # pragma: no cover - optional dependency
     class _MissingChroma:  # minimal stub so tests can patch PersistentClient
+        class Settings:
+            def __init__(self, *args, **kwargs):
+                raise ImportError("chromadb is required for this feature")
+
         class PersistentClient:
             def __init__(self, *args, **kwargs):
                 raise ImportError("chromadb is required for this feature")
@@ -39,10 +43,16 @@ class SegmentSaver(Runnable):
         output_dir: str = "clips",
         end_buffer_ms: int = 50,
         trim_silence: bool = True,
+        allow_reset: bool = False,
     ) -> None:
         self.output_dir = output_dir
         os.makedirs(self.output_dir, exist_ok=True)
-        self.client = chromadb.PersistentClient(path=db_path)
+        self.allow_reset = allow_reset
+        if allow_reset:
+            settings = chromadb.Settings(allow_reset=True)
+            self.client = chromadb.PersistentClient(path=db_path, settings=settings)
+        else:
+            self.client = chromadb.PersistentClient(path=db_path)
         self.collection = self.client.get_or_create_collection(collection_name)
         self.end_buffer_ms = max(0, int(end_buffer_ms))
         self.trim_silence = trim_silence
@@ -135,7 +145,10 @@ class SegmentSaver(Runnable):
         Removes all collections using :meth:`chromadb.PersistentClient.reset`.
         Useful for cleaning up between runs or tests.  The same operation can be
         invoked from the command line with ``python -m emotion_knowledge
-        --reset-db``.
+        --reset-db``.  The :class:`SegmentSaver` must be constructed with
+        ``allow_reset=True`` for this operation to succeed.
         """
 
+        if not self.allow_reset:
+            raise PermissionError("Reset requires allow_reset=True")
         self.client.reset()

--- a/tests/test_multimodal_emotion_tagger.py
+++ b/tests/test_multimodal_emotion_tagger.py
@@ -17,8 +17,9 @@ class FakeCollection:
 
 
 class FakeClient:
-    def __init__(self, path):
+    def __init__(self, path, settings=None):
         self.path = path
+        self.settings = settings
         self.collection = FakeCollection()
         self.reset_called = False
 
@@ -71,7 +72,20 @@ def test_segment_saver_reset_db(monkeypatch, tmp_path):
         FakeClient,
     )
 
-    saver = SegmentSaver(db_path=str(tmp_path / "db"), output_dir=str(tmp_path))
+    saver = SegmentSaver(
+        db_path=str(tmp_path / "db"), output_dir=str(tmp_path), allow_reset=True
+    )
     saver.reset_db()
     assert saver.client.reset_called
+
+
+def test_segment_saver_reset_requires_flag(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "emotion_knowledge.segment_saver.chromadb.PersistentClient",
+        FakeClient,
+    )
+
+    saver = SegmentSaver(db_path=str(tmp_path / "db"), output_dir=str(tmp_path))
+    with pytest.raises(PermissionError):
+        saver.reset_db()
 


### PR DESCRIPTION
## Summary
- allow opt-in database resets by adding `allow_reset` to `SegmentSaver`
- wire `--reset-db` CLI flag to create the client with `allow_reset=True`
- update tests for new reset flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e929dd3c83299bb83f976313d6d1