### PR TITLE
Document CLI options and database columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,54 @@ For example, the following command uses the smaller `base` model:
 python -m emotion_knowledge path/to/audio.wav --diarize --whisperx-model base
 ```
 
+### CLI options
+
+Run `python -m emotion_knowledge [options] path/to/audio.wav` to control the
+workflow:
+
+- `--diarize`: run WhisperX speaker diarization and store utterances in ChromaDB.
+- `--db-path PATH`: location for the ChromaDB database (default `segment_db`).
+- `--clip-dir DIR`: directory where audio snippets for each utterance are saved
+  (default `clips`).
+- `--whisperx-model SIZE`: WhisperX model size (`base`, `small`, `medium`,
+  `large`; default `medium`).
+- `--preserve-backchannels` / `--no-preserve-backchannels`: keep short
+  interjections as separate utterances or merge them into surrounding speech
+  (default keep).
+- `--preserve-end-times`: preserve original end timestamps (enabled by default).
+- `--export-words-xlsx`: export word-level transcripts to an Excel file (CSV
+  fallback).
+- `--reset-db`: clear existing ChromaDB collections before processing.
+
 The script prints the resulting transcription to the console.
+
+## Database columns
+
+Each diarized utterance stored in ChromaDB includes the following metadata:
+
+- `speaker`: speaker label assigned by the diarization model.
+- `start_time`: start time of the utterance in seconds.
+- `end_time`: end time of the utterance in seconds.
+- `text`: transcribed text for the utterance.
+- `audio_clip_path`: file path to the extracted audio snippet.
+
+Additional statistics recorded per utterance:
+
+- `duration`: utterance length in seconds.
+- `n_words`: number of words in the utterance.
+- `words_per_sec`: speaking rate calculated as words per second.
+- `mean_word_gap`: average silence between consecutive words.
+- `p95_word_gap`: 95th percentile of the word-gap distribution.
+- `overlaps_started`: whether the utterance begins while another speaker is
+  still talking.
+
+If you run the emotion annotators, further fields are appended:
+
+- `audio_emotion_label`: dominant emotion predicted from the audio clip.
+- `audio_emotion_confidence`: confidence score for the audio emotion label.
+- `audio_text`: transcript stored alongside the audio emotion data.
+- `text_emotion_label`: emotion predicted from the transcribed text.
+- `text_emotion_confidence`: confidence score for the text emotion label.
 
 ## Running on Google Colab
 


### PR DESCRIPTION
## Summary
- Expand README to list all CLI flags including `--reset-db` and `--export-words-xlsx`
- Add section explaining database metadata fields for diarized segments and emotion annotations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a21d561188329b33de8560eff63b8