### PR TITLE
Use grouped utterances for word backchannel export

### DIFF
--- a/tests/test_export_word_level_excel.py
+++ b/tests/test_export_word_level_excel.py
@@ -40,3 +40,28 @@ def test_export_word_level_excel_fallback_csv(tmp_path, monkeypatch):
         df.loc[0, "end"] - df.loc[0, "start"]
     )
 
+
+def test_export_word_level_excel_backchannel_tags(tmp_path, monkeypatch):
+    words = [
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.3, "text": "hi"},
+        {"segment": 0, "speaker": "A", "start": 0.35, "end": 0.6, "text": "there"},
+        {"segment": 0, "speaker": "A", "start": 0.65, "end": 0.9, "text": "everyone"},
+        {"segment": 0, "speaker": "A", "start": 0.95, "end": 1.2, "text": "today"},
+        {"segment": 1, "speaker": "B", "start": 1.3, "end": 1.4, "text": "um"},
+        {"segment": 2, "speaker": "A", "start": 1.5, "end": 1.7, "text": "how"},
+        {"segment": 2, "speaker": "A", "start": 1.75, "end": 1.95, "text": "are"},
+        {"segment": 2, "speaker": "A", "start": 2.0, "end": 2.2, "text": "you"},
+        {"segment": 2, "speaker": "A", "start": 2.25, "end": 2.6, "text": "doing"},
+    ]
+
+    def raise_import_error(*args, **kwargs):
+        raise ImportError("openpyxl missing")
+
+    monkeypatch.setattr(pd.DataFrame, "to_excel", raise_import_error)
+    out = tmp_path / "Single_Word_Transcript.xlsx"
+    path = export_word_level_excel(words, str(out))
+    df = pd.read_csv(path)
+
+    assert df[df["speaker"] == "B"]["is_backchannel"].all()
+    assert not df[df["speaker"] == "A"]["is_backchannel"].any()
+


### PR DESCRIPTION
## Summary
- Use `_group_utterances` to assign backchannel tags in `export_word_level_excel`
- Add test ensuring only interjection words are flagged as backchannels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee808e4b88329856ff3cd113f5b7d