### PR TITLE
Detect backchannels from speaker runs

### DIFF
--- a/tests/test_export_word_level_excel.py
+++ b/tests/test_export_word_level_excel.py
@@ -31,7 +31,7 @@ def test_export_word_level_excel_fallback_csv(tmp_path, monkeypatch):
         "end",
         "duration",
         "text",
-        "is_backchannel",
+        "Is_backchannel",
     ]
     # missing end timestamp should fallback to start
     assert df.loc[1, "end"] == pytest.approx(df.loc[1, "start"])
@@ -43,15 +43,19 @@ def test_export_word_level_excel_fallback_csv(tmp_path, monkeypatch):
 
 def test_export_word_level_excel_backchannel_tags(tmp_path, monkeypatch):
     words = [
-        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.3, "text": "hi"},
-        {"segment": 0, "speaker": "A", "start": 0.35, "end": 0.6, "text": "there"},
-        {"segment": 0, "speaker": "A", "start": 0.65, "end": 0.9, "text": "everyone"},
-        {"segment": 0, "speaker": "A", "start": 0.95, "end": 1.2, "text": "today"},
-        {"segment": 1, "speaker": "B", "start": 1.3, "end": 1.4, "text": "um"},
-        {"segment": 2, "speaker": "A", "start": 1.5, "end": 1.7, "text": "how"},
-        {"segment": 2, "speaker": "A", "start": 1.75, "end": 1.95, "text": "are"},
-        {"segment": 2, "speaker": "A", "start": 2.0, "end": 2.2, "text": "you"},
-        {"segment": 2, "speaker": "A", "start": 2.25, "end": 2.6, "text": "doing"},
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.1, "text": "Hi"},
+        {"segment": 0, "speaker": "A", "start": 0.1, "end": 0.2, "text": "there"},
+        {"segment": 0, "speaker": "B", "start": 0.2, "end": 0.3, "text": "can"},
+        {"segment": 0, "speaker": "B", "start": 0.3, "end": 0.4, "text": "you"},
+        {"segment": 0, "speaker": "B", "start": 0.4, "end": 0.5, "text": "hear"},
+        {"segment": 0, "speaker": "C", "start": 0.5, "end": 0.6, "text": "me"},
+        {"segment": 0, "speaker": "C", "start": 0.6, "end": 0.7, "text": "?"},
+        {"segment": 0, "speaker": "A", "start": 0.7, "end": 0.8, "text": "yes"},
+        {"segment": 1, "speaker": "D", "start": 0.0, "end": 0.1, "text": "Well"},
+        {"segment": 1, "speaker": "E", "start": 0.1, "end": 0.2, "text": "I"},
+        {"segment": 1, "speaker": "E", "start": 0.2, "end": 0.3, "text": "think"},
+        {"segment": 1, "speaker": "E", "start": 0.3, "end": 0.4, "text": "so"},
+        {"segment": 1, "speaker": "D", "start": 0.4, "end": 0.5, "text": "okay"},
     ]
 
     def raise_import_error(*args, **kwargs):
@@ -62,6 +66,12 @@ def test_export_word_level_excel_backchannel_tags(tmp_path, monkeypatch):
     path = export_word_level_excel(words, str(out))
     df = pd.read_csv(path)
 
-    assert df[df["speaker"] == "B"]["is_backchannel"].all()
-    assert not df[df["speaker"] == "A"]["is_backchannel"].any()
+    # segment 0: speaker B has 3-word run -> backchannel
+    assert df[(df["segment"] == 0) & (df["speaker"] == "B")]["Is_backchannel"].all()
+    # speaker C run is only 2 words -> not backchannel
+    assert not df[(df["segment"] == 0) & (df["speaker"] == "C")]["Is_backchannel"].any()
+    # segment 1: speaker E has 3-word run -> backchannel
+    assert df[(df["segment"] == 1) & (df["speaker"] == "E")]["Is_backchannel"].all()
+    # primary speaker D remains False
+    assert not df[(df["segment"] == 1) & (df["speaker"] == "D")]["Is_backchannel"].any()
 

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -67,55 +67,6 @@ def test_end_time_not_modified_when_disabled():
     assert result[0]["end"] == pytest.approx(1.0)
 
 
-def test_short_interjection_becomes_backchannel():
-    segments = [
-        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
-        {"speaker": "s2", "start": 0.5, "end": 0.6, "word": "hm"},
-        {"speaker": "s1", "start": 0.6, "end": 1.0, "word": "Welt"},
-    ]
-    result = _group_utterances(segments)
-    assert [utt["text"] for utt in result] == ["Hallo", "hm", "Welt"]
-    assert result[1]["is_backchannel"] is True
-
-
-def test_long_single_word_interjection_backchannel():
-    segments = [
-        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
-        {"speaker": "s2", "start": 0.5, "end": 1.4, "word": "hm"},
-        {"speaker": "s1", "start": 1.4, "end": 2.0, "word": "Welt"},
-    ]
-    result = _group_utterances(segments)
-    assert [utt["text"] for utt in result] == ["Hallo", "hm", "Welt"]
-    assert result[1]["is_backchannel"] is True
-
-
-def test_multi_word_interjection_tagged_backchannel():
-    segments = [
-        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
-        {"speaker": "s2", "start": 0.5, "end": 1.7, "text": "ach so"},
-        {"speaker": "s1", "start": 1.7, "end": 2.2, "word": "Welt"},
-    ]
-    result = _group_utterances(segments)
-    assert [utt["text"] for utt in result] == ["Hallo", "ach so", "Welt"]
-    assert result[1]["is_backchannel"] is True
-
-
-def test_long_multi_word_interruption_not_backchannel():
-    segments = [
-        {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
-        {
-            "speaker": "s2",
-            "start": 0.5,
-            "end": 2.0,
-            "text": "das ist aber wirklich",
-        },
-        {"speaker": "s1", "start": 2.0, "end": 2.5, "word": "Welt"},
-    ]
-    result = _group_utterances(segments)
-    assert [utt["text"] for utt in result] == ["Hallo", "das ist aber wirklich", "Welt"]
-    assert "is_backchannel" not in result[1]
-
-
 def test_same_segment_id_overrides_gap():
     segments = [
         {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo", "segment": 0},


### PR DESCRIPTION
## Summary
- compute backchannel flags from runs of three+ words by alternate speakers
- drop duration/word-count heuristics from utterance grouping
- update tests for new Is_backchannel column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f42c63c4c832985cda794cbd4523b