### PR TITLE
feat: add run-based backchannel tagging

### DIFF
--- a/emotion_knowledge/__init__.py
+++ b/emotion_knowledge/__init__.py
@@ -52,10 +52,8 @@ def _group_utterances(
     segments_info=None,
     merge_sentences: bool = False,
     absorb_interjections: bool = False,
-    backchannel_max_dur: float = 0.7,
-    backchannel_max_words: int = 3,
-    tag_backchannels: bool = True,
-    preserve_end_times: bool = True,
+    multi_spk_seg_min_words: int | None = None,
+    backchannel_run_min_words: int | None = None,
 ):
     """Merge word-level segments into full utterances.
 
@@ -73,32 +71,25 @@ def _group_utterances(
         When ``True`` short interjections from other speakers are merged back
         into the surrounding utterance.  When ``False`` (default) they remain
         separate utterances.
-    backchannel_max_dur : float, optional
-        Maximum duration (in seconds) for an utterance to qualify as a
-        backchannel.
-    backchannel_max_words : int, optional
-        Maximum number of words for an utterance to qualify as a backchannel.
-    tag_backchannels : bool, optional
-        When ``True`` add ``is_backchannel=True`` to detected backchannels.
-    preserve_end_times : bool, optional
-        Deprecated. End timestamps are always taken from the final word in each
-        utterance. This parameter is retained for backwards compatibility and
-        has no effect.
+    multi_spk_seg_min_words : int | None, optional
+        Minimum total words in a multi-speaker segment required to apply the
+        run-based utterance/backchannel logic. If ``None`` the standard
+        grouping logic is used.
+    backchannel_run_min_words : int | None, optional
+        Minimum consecutive words spoken by the same speaker (a run) for that
+        run to be tagged with ``is_backchannel=True``. Only used when
+        ``multi_spk_seg_min_words`` is also provided.
+
+    If both ``multi_spk_seg_min_words`` and ``backchannel_run_min_words`` are
+    set (not ``None``), use run-based utterance creation and backchannel tagging
+    within multi-speaker segments. Otherwise, use the standard grouping logic.
+    Old duration/word-count backchannel logic is removed.
     """
 
     if not segments:
         return []
 
     logger.info("Grouping %d word segments into utterances", len(segments))
-
-    def _is_backchannel(seg):
-        dur = seg["end"] - seg["start"]
-        wc = len(seg["text"].strip().split())
-        return dur <= backchannel_max_dur or wc <= backchannel_max_words
-
-    def _tag_backchannel(utt):
-        if tag_backchannels and _is_backchannel(utt):
-            utt["is_backchannel"] = True
 
     norm_segments = []
     fallback_dur = 0.1
@@ -130,6 +121,10 @@ def _group_utterances(
     elif all(seg.get("segment") is not None for seg in norm_segments):
         use_segment_ids = True
 
+    use_new_run_logic = (
+        multi_spk_seg_min_words is not None and backchannel_run_min_words is not None
+    )
+
     grouped = []
     if use_segment_ids:
         ordered_groups = []
@@ -153,6 +148,34 @@ def _group_utterances(
                 ordered_groups.append(buf)
 
         for group in ordered_groups:
+            if use_new_run_logic:
+                speakers_in_group = {w["speaker"] for w in group}
+                if len(group) >= multi_spk_seg_min_words and len(speakers_in_group) >= 2:
+                    runs = []
+                    run_speaker = group[0]["speaker"]
+                    run_words = [group[0]]
+                    for w in group[1:]:
+                        if w["speaker"] == run_speaker:
+                            run_words.append(w)
+                        else:
+                            runs.append((run_speaker, run_words))
+                            run_speaker = w["speaker"]
+                            run_words = [w]
+                    runs.append((run_speaker, run_words))
+
+                    for spk, words_run in runs:
+                        utt = {
+                            "speaker": spk,
+                            "start": words_run[0]["start"],
+                            "end": words_run[-1]["end"],
+                            "text": " ".join(w["text"] for w in words_run),
+                            "words": words_run,
+                        }
+                        if len(words_run) >= backchannel_run_min_words:
+                            utt["is_backchannel"] = True
+                        grouped.append(utt)
+                    continue
+
             speaker_counts = {}
             for w in group:
                 sp = w["speaker"]
@@ -167,18 +190,18 @@ def _group_utterances(
                 "text": " ".join(w["text"] for w in group),
                 "words": group,
             }
-            _tag_backchannel(utt)
             grouped.append(utt)
 
         if merge_sentences and grouped:
             merged = [grouped[0].copy()]
             merged[0]["words"] = grouped[0]["words"].copy()
             for utt in grouped[1:]:
-                if (
+                can_merge = (
                     utt["speaker"] == merged[-1]["speaker"]
                     and not merged[-1].get("is_backchannel")
                     and not utt.get("is_backchannel")
-                ):
+                )
+                if can_merge:
                     merged[-1]["text"] += " " + utt["text"]
                     merged[-1]["end"] = utt["end"]
                     merged[-1]["words"].extend(utt.get("words", []))
@@ -197,23 +220,13 @@ def _group_utterances(
         current = norm_segments[0].copy()
         current_words = [norm_segments[0].copy()]
         prev_speaker = None
-        suppress_tag = False
 
         def append_current(utt, words):
             """Finalize the current utterance and store its word list."""
-            nonlocal prev_speaker, suppress_tag
-            if (
-                tag_backchannels
-                and not suppress_tag
-                and prev_speaker is not None
-                and utt["speaker"] != prev_speaker
-                and _is_backchannel(utt)
-            ):
-                utt["is_backchannel"] = True
+            nonlocal prev_speaker
             utt["words"] = words
             grouped.append(utt)
             prev_speaker = utt["speaker"]
-            suppress_tag = False
 
         # interjections shorter than this duration or consisting of a single word
         # are candidates to be absorbed
@@ -254,12 +267,9 @@ def _group_utterances(
                 else:
                     append_current(current, current_words)
                     interj = seg.copy()
-                    if tag_backchannels and _is_backchannel(interj):
-                        interj["is_backchannel"] = True
                     append_current(interj, [seg])
                     current = norm_segments[i + 1].copy()
                     current_words = [norm_segments[i + 1].copy()]
-                    suppress_tag = True
                     i += 2
                     continue
 
@@ -272,11 +282,8 @@ def _group_utterances(
             merged = [grouped[0].copy()]
             merged[0]["words"] = grouped[0]["words"].copy()
             for utt in grouped[1:]:
-                if (
-                    utt["speaker"] == merged[-1]["speaker"]
-                    and not merged[-1].get("is_backchannel")
-                    and not utt.get("is_backchannel")
-                ):
+                can_merge = utt["speaker"] == merged[-1]["speaker"]
+                if can_merge:
                     merged[-1]["text"] += " " + utt["text"]
                     merged[-1]["end"] = utt["end"]
                     merged[-1]["words"].extend(utt.get("words", []))
@@ -477,8 +484,8 @@ def _split_multispeaker_segments(words):
 def export_word_level_excel(
     words,
     path: str = "Single_Word_Transcript.xlsx",
-    backchannel_max_dur: float = 0.7,
-    backchannel_max_words: int = 3,
+    multi_spk_seg_min_words: int | None = None,
+    backchannel_run_min_words: int | None = None,
 ):
     """Export word-level segments to Excel with a CSV fallback.
 
@@ -488,10 +495,12 @@ def export_word_level_excel(
         Word-level diarization results.
     path : str, optional
         Output path for the Excel file.
-    backchannel_max_dur : float, optional
-        Duration threshold for backchannel detection in seconds.
-    backchannel_max_words : int, optional
-        Word-count threshold for backchannel detection.
+    multi_spk_seg_min_words : int | None, optional
+        Minimum total words in a segment to enable run-based
+        utterance/backchannel logic.
+    backchannel_run_min_words : int | None, optional
+        Minimum consecutive words by the same speaker (run) to tag that run as a
+        backchannel. Only used when ``multi_spk_seg_min_words`` is also set.
     """
 
     if not words:
@@ -501,9 +510,8 @@ def export_word_level_excel(
 
     utterances = _group_utterances(
         words,
-        backchannel_max_dur=backchannel_max_dur,
-        backchannel_max_words=backchannel_max_words,
-        tag_backchannels=True,
+        multi_spk_seg_min_words=multi_spk_seg_min_words,
+        backchannel_run_min_words=backchannel_run_min_words,
     )
     utterances = sorted(utterances, key=lambda u: u.get("start", 0))
 
@@ -699,6 +707,8 @@ class WhisperXDiarizationWorkflow(Runnable):
         preserve_backchannels: bool = True,
         preserve_end_times: bool = True,
         export_words_xlsx: bool = False,
+        multi_spk_seg_min_words: int | None = None,
+        backchannel_run_min_words: int | None = None,
     ) -> str:
         logger.info("Transcribing and diarizing %s", audio_path)
         result = transcribe_diarize_whisperx.invoke(
@@ -716,7 +726,12 @@ class WhisperXDiarizationWorkflow(Runnable):
         if segments:
             logger.debug("First diarized segment: %s", segments[0])
             if export_words_xlsx:
-                export_word_level_excel(segments, "Single_Word_Transcript.xlsx")
+                export_word_level_excel(
+                    segments,
+                    "Single_Word_Transcript.xlsx",
+                    multi_spk_seg_min_words=multi_spk_seg_min_words,
+                    backchannel_run_min_words=backchannel_run_min_words,
+                )
             if SegmentSaver is None:
                 raise ImportError("SegmentSaver requires optional dependencies")
             saver = SegmentSaver(db_path=db_path, output_dir=clip_dir)
@@ -726,10 +741,8 @@ class WhisperXDiarizationWorkflow(Runnable):
                 segments_info=result.get("segments_info"),
                 merge_sentences=True,
                 absorb_interjections=not preserve_backchannels,
-                tag_backchannels=True,
-                backchannel_max_dur=0.7,
-                backchannel_max_words=3,
-                preserve_end_times=preserve_end_times,
+                multi_spk_seg_min_words=multi_spk_seg_min_words,
+                backchannel_run_min_words=backchannel_run_min_words,
             )
             logger.info("Saving %d utterances to %s", len(utterances), clip_dir)
             for idx, utt in enumerate(utterances, 1):
@@ -777,6 +790,18 @@ def main():
         action="store_true",
         help="Export word-level transcript to Excel (CSV fallback)",
     )
+    parser.add_argument(
+        "--multi-spk-seg-min-words",
+        type=int,
+        default=None,
+        help="Min total words in a segment to enable run-based utterance/backchannel logic",
+    )
+    parser.add_argument(
+        "--backchannel-run-min-words",
+        type=int,
+        default=None,
+        help="Min consecutive words by same speaker (run) to tag that run as backchannel",
+    )
     args = parser.parse_args()
 
     if args.diarize:
@@ -789,6 +814,8 @@ def main():
             preserve_backchannels=args.preserve_backchannels,
             preserve_end_times=args.preserve_end_times,
             export_words_xlsx=args.export_words_xlsx,
+            multi_spk_seg_min_words=args.multi_spk_seg_min_words,
+            backchannel_run_min_words=args.backchannel_run_min_words,
         )
     else:
         workflow = TranscriptionOnlyWorkflow()

--- a/tests/test_export_word_level_excel.py
+++ b/tests/test_export_word_level_excel.py
@@ -43,15 +43,15 @@ def test_export_word_level_excel_fallback_csv(tmp_path, monkeypatch):
 
 def test_export_word_level_excel_backchannel_tags(tmp_path, monkeypatch):
     words = [
-        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.3, "text": "hi"},
-        {"segment": 0, "speaker": "A", "start": 0.35, "end": 0.6, "text": "there"},
-        {"segment": 0, "speaker": "A", "start": 0.65, "end": 0.9, "text": "everyone"},
-        {"segment": 0, "speaker": "A", "start": 0.95, "end": 1.2, "text": "today"},
-        {"segment": 1, "speaker": "B", "start": 1.3, "end": 1.4, "text": "um"},
-        {"segment": 2, "speaker": "A", "start": 1.5, "end": 1.7, "text": "how"},
-        {"segment": 2, "speaker": "A", "start": 1.75, "end": 1.95, "text": "are"},
-        {"segment": 2, "speaker": "A", "start": 2.0, "end": 2.2, "text": "you"},
-        {"segment": 2, "speaker": "A", "start": 2.25, "end": 2.6, "text": "doing"},
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.1, "text": "hi"},
+        {"segment": 0, "speaker": "A", "start": 0.2, "end": 0.3, "text": "there"},
+        {"segment": 0, "speaker": "A", "start": 0.35, "end": 0.45, "text": "everyone"},
+        {"segment": 0, "speaker": "B", "start": 0.5, "end": 0.6, "text": "um"},
+        {"segment": 0, "speaker": "B", "start": 0.65, "end": 0.75, "text": "yes"},
+        {"segment": 0, "speaker": "B", "start": 0.8, "end": 0.9, "text": "indeed"},
+        {"segment": 0, "speaker": "B", "start": 0.95, "end": 1.05, "text": "haha"},
+        {"segment": 0, "speaker": "A", "start": 1.1, "end": 1.2, "text": "ok"},
+        {"segment": 0, "speaker": "A", "start": 1.25, "end": 1.35, "text": "bye"},
     ]
 
     def raise_import_error(*args, **kwargs):
@@ -59,9 +59,15 @@ def test_export_word_level_excel_backchannel_tags(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pd.DataFrame, "to_excel", raise_import_error)
     out = tmp_path / "Single_Word_Transcript.xlsx"
-    path = export_word_level_excel(words, str(out))
+    path = export_word_level_excel(
+        words,
+        str(out),
+        multi_spk_seg_min_words=8,
+        backchannel_run_min_words=3,
+    )
     df = pd.read_csv(path)
 
-    assert df[df["speaker"] == "B"]["is_backchannel"].all()
-    assert not df[df["speaker"] == "A"]["is_backchannel"].any()
+    assert df.iloc[0:3]["is_backchannel"].all()
+    assert df.iloc[3:7]["is_backchannel"].all()
+    assert not df.iloc[7:]["is_backchannel"].any()
 

--- a/tests/test_group_utterances.py
+++ b/tests/test_group_utterances.py
@@ -61,13 +61,13 @@ def test_end_time_not_modified_when_disabled():
         {"speaker": "speaker_01", "start": 0.0, "end": 1.0, "word": "Hallo"},
         {"speaker": "speaker_01", "start": 5.0, "end": 5.5, "word": "Welt"},
     ]
-    result = _group_utterances(segments, preserve_end_times=False)
+    result = _group_utterances(segments)
     assert len(result) == 2
     # end timestamps come from the final word regardless of preserve_end_times
     assert result[0]["end"] == pytest.approx(1.0)
 
 
-def test_short_interjection_becomes_backchannel():
+def test_short_interjection_not_backchannel():
     segments = [
         {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
         {"speaker": "s2", "start": 0.5, "end": 0.6, "word": "hm"},
@@ -75,10 +75,10 @@ def test_short_interjection_becomes_backchannel():
     ]
     result = _group_utterances(segments)
     assert [utt["text"] for utt in result] == ["Hallo", "hm", "Welt"]
-    assert result[1]["is_backchannel"] is True
+    assert "is_backchannel" not in result[1]
 
 
-def test_long_single_word_interjection_backchannel():
+def test_long_single_word_interjection_not_backchannel():
     segments = [
         {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
         {"speaker": "s2", "start": 0.5, "end": 1.4, "word": "hm"},
@@ -86,10 +86,10 @@ def test_long_single_word_interjection_backchannel():
     ]
     result = _group_utterances(segments)
     assert [utt["text"] for utt in result] == ["Hallo", "hm", "Welt"]
-    assert result[1]["is_backchannel"] is True
+    assert "is_backchannel" not in result[1]
 
 
-def test_multi_word_interjection_tagged_backchannel():
+def test_multi_word_interjection_not_backchannel():
     segments = [
         {"speaker": "s1", "start": 0.0, "end": 0.5, "word": "Hallo"},
         {"speaker": "s2", "start": 0.5, "end": 1.7, "text": "ach so"},
@@ -97,7 +97,7 @@ def test_multi_word_interjection_tagged_backchannel():
     ]
     result = _group_utterances(segments)
     assert [utt["text"] for utt in result] == ["Hallo", "ach so", "Welt"]
-    assert result[1]["is_backchannel"] is True
+    assert "is_backchannel" not in result[1]
 
 
 def test_long_multi_word_interruption_not_backchannel():
@@ -114,6 +114,61 @@ def test_long_multi_word_interruption_not_backchannel():
     result = _group_utterances(segments)
     assert [utt["text"] for utt in result] == ["Hallo", "das ist aber wirklich", "Welt"]
     assert "is_backchannel" not in result[1]
+
+
+def test_run_based_backchannel_tagging():
+    segments = [
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.1, "text": "hi"},
+        {"segment": 0, "speaker": "A", "start": 0.1, "end": 0.2, "text": "there"},
+        {"segment": 0, "speaker": "A", "start": 0.2, "end": 0.3, "text": "everyone"},
+        {"segment": 0, "speaker": "B", "start": 0.3, "end": 0.4, "text": "um"},
+        {"segment": 0, "speaker": "B", "start": 0.4, "end": 0.5, "text": "yes"},
+        {"segment": 0, "speaker": "B", "start": 0.5, "end": 0.6, "text": "indeed"},
+        {"segment": 0, "speaker": "B", "start": 0.6, "end": 0.7, "text": "haha"},
+        {"segment": 0, "speaker": "A", "start": 0.7, "end": 0.8, "text": "ok"},
+        {"segment": 0, "speaker": "A", "start": 0.8, "end": 0.9, "text": "bye"},
+    ]
+    result = _group_utterances(
+        segments,
+        multi_spk_seg_min_words=8,
+        backchannel_run_min_words=3,
+    )
+    assert len(result) == 3
+    assert [utt["text"] for utt in result] == [
+        "hi there everyone",
+        "um yes indeed haha",
+        "ok bye",
+    ]
+    assert result[0]["is_backchannel"] is True
+    assert result[1]["is_backchannel"] is True
+    assert "is_backchannel" not in result[2]
+
+
+def test_merge_sentences_skips_backchannels():
+    segments = [
+        {"segment": 0, "speaker": "A", "start": 0.0, "end": 0.1, "text": "hi"},
+        {"segment": 0, "speaker": "A", "start": 0.1, "end": 0.2, "text": "there"},
+        {"segment": 0, "speaker": "B", "start": 0.2, "end": 0.3, "text": "um"},
+        {"segment": 0, "speaker": "B", "start": 0.3, "end": 0.4, "text": "yes"},
+        {"segment": 0, "speaker": "B", "start": 0.4, "end": 0.5, "text": "indeed"},
+        {"segment": 0, "speaker": "A", "start": 0.5, "end": 0.6, "text": "ok"},
+        {"segment": 1, "speaker": "A", "start": 0.7, "end": 0.8, "text": "bye"},
+    ]
+    result = _group_utterances(
+        segments,
+        merge_sentences=True,
+        multi_spk_seg_min_words=5,
+        backchannel_run_min_words=3,
+    )
+    assert len(result) == 3
+    assert [utt["text"] for utt in result] == [
+        "hi there",
+        "um yes indeed",
+        "ok bye",
+    ]
+    assert "is_backchannel" not in result[0]
+    assert result[1]["is_backchannel"] is True
+    assert "is_backchannel" not in result[2]
 
 
 def test_same_segment_id_overrides_gap():


### PR DESCRIPTION
## Summary
- add optional run-based utterance grouping/backchannel logic
- support run-based tagging in Excel export and workflows
- expose CLI flags to configure run-based segmentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a188dd5c9483298c9ed6f866cdd04c