### PR TITLE
Add Chainlit chat app for diarized transcript retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,23 @@ Replace `/path/to/audio.wav` with a file from your Google Drive or an uploaded
 sample. The results are printed to the notebook and, when diarization is
 enabled, stored in the local `segment_db` directory.
 
+## Interactive chat with Chainlit
+
+After diarizing and storing segments in ChromaDB, you can explore them with a
+chat interface. The example `chainlit_app.py` loads a Hugging Face chat model
+and retrieves relevant utterances from the `segment_db` to use as additional
+context. The model name and database path are controlled via environment
+variables so that different models can be swapped without code changes.
+
+Install the extra dependencies and start the app:
+
+```bash
+pip install -r requirements.txt  # includes chainlit and sentence-transformers
+chainlit run chainlit_app.py
+```
+
+Set `HF_MODEL` to point to any compatible chat model on the Hugging Face hub,
+for example `export HF_MODEL="meta-llama/Llama-2-7b-chat-hf"`. The app will
+automatically use transcripts stored in `segment_db/segments` as context for
+each user message.
+

--- a/chainlit_app.py
+++ b/chainlit_app.py
@@ -1,0 +1,31 @@
+import os
+import chainlit as cl
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+import chromadb
+from chromadb.utils import embedding_functions
+
+MODEL_NAME = os.getenv("HF_MODEL", "meta-llama/Llama-2-7b-chat-hf")
+SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "You are a helpful assistant.")
+DB_PATH = os.getenv("CHROMADB_PATH", "segment_db")
+COLLECTION_NAME = os.getenv("CHROMADB_COLLECTION", "segments")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+
+# Load LLM from HuggingFace model hub
+_tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, device_map="auto")
+_llm = pipeline("text-generation", model=_model, tokenizer=_tokenizer, max_new_tokens=256)
+
+# Connect to ChromaDB with diarized transcripts
+_client = chromadb.PersistentClient(path=DB_PATH)
+_collection = _client.get_collection(COLLECTION_NAME)
+_embedder = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=EMBED_MODEL)
+
+@cl.on_message
+async def main(message: str):
+    """Respond to a user message with context from diarized transcripts."""
+    query_embedding = _embedder(message)
+    results = _collection.query(query_embeddings=[query_embedding], n_results=3)
+    context = "\n".join(results["documents"][0])
+    prompt = f"{SYSTEM_PROMPT}\n{context}\nUser: {message}\nAssistant:"
+    output = _llm(prompt)[0]["generated_text"][len(prompt):]
+    await cl.Message(content=output).send()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ whisperx
 langchain-core
 chromadb
 pydub
+chainlit
+sentence-transformers


### PR DESCRIPTION
## Summary
- add `chainlit_app.py` to chat with a Hugging Face model using ChromaDB diarized transcripts as context
- document Chainlit usage in README
- include Chainlit and sentence-transformers in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a14ee6bc8329bea2dbe8dce6e860